### PR TITLE
fix(layout)[int]: calculate `DataLayout` for a given `Lir` scalar type

### DIFF
--- a/compiler/tidec/src/main.rs
+++ b/compiler/tidec/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
     debug!("Logging initialized");
 
     // TODO: check valitiy of TideArgs
-    let lir_ctx = LirCtx::new(BackendKind::Llvm, EmitKind::Object);
+    let lir_ctx = LirCtx::new(BackendKind::Llvm, EmitKind::LlvmIr);
 
     // Create a simple main function that returns 0.
     // ```c

--- a/compiler/tidec_abi/src/layout.rs
+++ b/compiler/tidec_abi/src/layout.rs
@@ -134,3 +134,4 @@ pub enum Primitive {
     /// A pointer type.
     Pointer(AddressSpace),
 }
+

--- a/compiler/tidec_abi/src/target.rs
+++ b/compiler/tidec_abi/src/target.rs
@@ -94,23 +94,22 @@ pub struct TargetDataLayout {
     /// The endianness of the target architecture.
     pub endianess: Endianess,
 
-    // Integer type alignments
-    pub i1_align: AbiAndPrefAlign,
-    pub i8_align: AbiAndPrefAlign,
-    pub i16_align: AbiAndPrefAlign,
-    pub i32_align: AbiAndPrefAlign,
-    pub i64_align: AbiAndPrefAlign,
-    pub i128_align: AbiAndPrefAlign,
+    // Integer type alignments, for both signed and unsigned integers.
+    pub int1_align: AbiAndPrefAlign,
+    pub int8_align: AbiAndPrefAlign,
+    pub int16_align: AbiAndPrefAlign,
+    pub int32_align: AbiAndPrefAlign,
+    pub int64_align: AbiAndPrefAlign,
+    pub int128_align: AbiAndPrefAlign,
 
     // Floating point type alignments
-    pub f16_align: AbiAndPrefAlign,
-    pub f32_align: AbiAndPrefAlign,
-    pub f64_align: AbiAndPrefAlign,
-    pub f128_align: AbiAndPrefAlign,
+    pub float16_align: AbiAndPrefAlign,
+    pub float32_align: AbiAndPrefAlign,
+    pub float64_align: AbiAndPrefAlign,
+    pub float128_align: AbiAndPrefAlign,
 
     /// The size of pointers in bytes.
-    pub pointer_size: u64,
-
+    pub pointer_size: Size,
     /// The ABI and preferred alignment for pointers.
     pub pointer_align: AbiAndPrefAlign,
 
@@ -130,17 +129,17 @@ impl Default for TargetDataLayout {
     fn default() -> Self {
         TargetDataLayout {
             endianess: Endianess::Big,
-            i1_align: AbiAndPrefAlign::new(8, 8),
-            i8_align: AbiAndPrefAlign::new(8, 8),
-            i16_align: AbiAndPrefAlign::new(16, 16),
-            i32_align: AbiAndPrefAlign::new(32, 32),
-            i64_align: AbiAndPrefAlign::new(32, 64),
-            i128_align: AbiAndPrefAlign::new(32, 64),
-            f16_align: AbiAndPrefAlign::new(16, 16),
-            f32_align: AbiAndPrefAlign::new(32, 32),
-            f64_align: AbiAndPrefAlign::new(64, 64),
-            f128_align: AbiAndPrefAlign::new(128, 128),
-            pointer_size: 64,
+            int1_align: AbiAndPrefAlign::new(8, 8),
+            int8_align: AbiAndPrefAlign::new(8, 8),
+            int16_align: AbiAndPrefAlign::new(16, 16),
+            int32_align: AbiAndPrefAlign::new(32, 32),
+            int64_align: AbiAndPrefAlign::new(32, 64),
+            int128_align: AbiAndPrefAlign::new(32, 64),
+            float16_align: AbiAndPrefAlign::new(16, 16),
+            float32_align: AbiAndPrefAlign::new(32, 32),
+            float64_align: AbiAndPrefAlign::new(64, 64),
+            float128_align: AbiAndPrefAlign::new(128, 128),
+            pointer_size: Size::from_bits(64),
             pointer_align: AbiAndPrefAlign::new(64, 64),
             aggregate_align: AbiAndPrefAlign::new(0, 64),
             vector_align: vec![
@@ -158,6 +157,16 @@ impl TargetDataLayout {
         let target_data_layout = TargetDataLayout::default();
         info!("TargetDataLayout created: {:?}", target_data_layout);
         target_data_layout
+    }
+
+    pub fn pointer_size(&self) -> Size {
+        self.pointer_size
+    }
+
+    pub fn pointer_align(&self, address_space: AddressSpace) -> AbiAndPrefAlign {
+        match address_space {
+            AddressSpace::DATA => self.pointer_align,
+        }
     }
 
     /// For example, for x86_64-unknown-linux-gnu, the data layout string could be:
@@ -179,24 +188,24 @@ impl TargetDataLayout {
         // Add pointer and integer alignments
         s.push_str(&format!(
             "-p:{}:{}:{}",
-            self.pointer_size,
+            self.pointer_size.bytes(),
             self.pointer_align.abi.bytes(),
             self.pointer_align.pref.bytes()
         ));
 
         // Format for integer types
-        s.push_str(&format_align("i1", &self.i1_align));
-        s.push_str(&format_align("i8", &self.i8_align));
-        s.push_str(&format_align("i16", &self.i16_align));
-        s.push_str(&format_align("i32", &self.i32_align));
-        s.push_str(&format_align("i64", &self.i64_align));
-        s.push_str(&format_align("i128", &self.i128_align));
+        s.push_str(&format_align("i1", &self.int1_align));
+        s.push_str(&format_align("i8", &self.int8_align));
+        s.push_str(&format_align("i16", &self.int16_align));
+        s.push_str(&format_align("i32", &self.int32_align));
+        s.push_str(&format_align("i64", &self.int64_align));
+        s.push_str(&format_align("i128", &self.int128_align));
 
         // Format for floating point types
-        s.push_str(&format_align("f16", &self.f16_align));
-        s.push_str(&format_align("f32", &self.f32_align));
-        s.push_str(&format_align("f64", &self.f64_align));
-        s.push_str(&format_align("f128", &self.f128_align));
+        s.push_str(&format_align("f16", &self.float16_align));
+        s.push_str(&format_align("f32", &self.float32_align));
+        s.push_str(&format_align("f64", &self.float64_align));
+        s.push_str(&format_align("f128", &self.float128_align));
 
         // Aggregate alignment
         s.push_str(&format_align("a", &self.aggregate_align));

--- a/compiler/tidec_codegen_llvm/src/context.rs
+++ b/compiler/tidec_codegen_llvm/src/context.rs
@@ -131,9 +131,8 @@ impl FnAbiOf for CodegenCtx<'_> {
         lir_ty_ctx: &LirCtx,
         lir_ret_and_args: &IdxVec<Local, LocalData>,
     ) -> FnAbi<LirTy> {
-        let layout_ctx = LayoutCtx::new(lir_ty_ctx);
         let argument_of = |ty: LirTy| -> ArgAbi<LirTy> {
-            let layout = layout_ctx.compute_layout(ty);
+            let layout = lir_ty_ctx.layout_of(ty);
             let pass_mode = match layout.backend_repr {
                 BackendRepr::Scalar(_) => PassMode::Direct,
                 BackendRepr::Memory => PassMode::Indirect,
@@ -281,6 +280,12 @@ impl<'ll> CodegenMethods<'ll> for CodegenCtx<'ll> {
                     .write_to_file(&self.ll_module, FileType::Assembly, Path::new(&asm_path))
                     .expect("Failed to write assembly file");
                 debug!("Wrote assembly file to {}", asm_path);
+            }
+            EmitKind::LlvmIr => {
+                let ir_path = format!("{}.ll", self.ll_module.get_name().to_str().unwrap());
+                std::fs::write(&ir_path, self.ll_module.print_to_string().to_string())
+                    .expect("Failed to write LLVM IR file");
+                debug!("Wrote LLVM IR file to {}", ir_path);
             }
         }
     }

--- a/compiler/tidec_lir/src/layout_ctx.rs
+++ b/compiler/tidec_lir/src/layout_ctx.rs
@@ -49,7 +49,10 @@ impl<'a> LayoutCtx<'a> {
             LirTy::I32 => scalar(Primitive::I32),
             LirTy::I64 => scalar(Primitive::I64),
             LirTy::I128 => scalar(Primitive::I128),
-            LirTy::Metadata => unimplemented!("Metadata type layout not implemented"),
+            // TODO: Implement layout computation for Metadata types (e.g., for unsized types or trait objects).
+            // Metadata represents type information for unsized types (such as slices or trait objects),
+            // which require special handling for their layout. Support for this will be added in a future release.
+            LirTy::Metadata => unimplemented!("Layout computation for LirTy::Metadata (used for unsized types/trait objects) is not yet supported. See TODO comment for details."),
         };
 
         TyAndLayout {

--- a/compiler/tidec_lir/src/layout_ctx.rs
+++ b/compiler/tidec_lir/src/layout_ctx.rs
@@ -1,35 +1,73 @@
-use crate::lir::LirCtx;
+use crate::{lir::LirCtx, syntax::LirTy};
 use tidec_abi::{
     layout::{BackendRepr, Layout, Primitive, TyAndLayout},
     size_and_align::{AbiAndPrefAlign, Size},
 };
 
 pub struct LayoutCtx<'a> {
-    _lir_ty_ctx: &'a LirCtx,
+    lir_ctx: &'a LirCtx,
 }
 
 impl<'a> LayoutCtx<'a> {
-    // It accepts the `LirTyCtx` because it contains the `TargetDataLayout`.
-    pub fn new(lir_ty_ctx: &'a LirCtx) -> Self {
-        LayoutCtx {
-            _lir_ty_ctx: lir_ty_ctx,
-        }
+    // It accepts the `LirCtx` because it contains the `TargetDataLayout`.
+    pub fn new(lir_ctx: &'a LirCtx) -> Self {
+        LayoutCtx { lir_ctx }
     }
 
     /// Computes the layout for a given type. We should cache the results
     /// to avoid recomputing the layout for the same type multiple times.
-    pub fn compute_layout<T>(&self, ty: T) -> TyAndLayout<T> {
-        let _ = ty;
-        // let data_layout = self.target.data_layout;
+    pub fn compute_layout(&self, ty: LirTy) -> TyAndLayout<LirTy> {
+        let data_layout = &self.lir_ctx.target().data_layout;
 
-        // HARDCODE FOR TESTING an integer type
+        let scalar = |primitive: Primitive| -> (Size, AbiAndPrefAlign, BackendRepr) {
+            let (size, align) = match primitive {
+                Primitive::I8 => (Size::from_bits(8), data_layout.int8_align),
+                Primitive::I16 => (Size::from_bits(16), data_layout.int16_align),
+                Primitive::I32 => (Size::from_bits(32), data_layout.int32_align),
+                Primitive::I64 => (Size::from_bits(64), data_layout.int64_align),
+                Primitive::I128 => (Size::from_bits(128), data_layout.int128_align),
+                Primitive::U8 => (Size::from_bits(8), data_layout.int8_align),
+                Primitive::U16 => (Size::from_bits(16), data_layout.int16_align),
+                Primitive::U32 => (Size::from_bits(32), data_layout.int32_align),
+                Primitive::U64 => (Size::from_bits(64), data_layout.int64_align),
+                Primitive::U128 => (Size::from_bits(128), data_layout.int128_align),
+                Primitive::F16 => (Size::from_bits(16), data_layout.float16_align),
+                Primitive::F32 => (Size::from_bits(32), data_layout.float32_align),
+                Primitive::F64 => (Size::from_bits(64), data_layout.float64_align),
+                Primitive::F128 => (Size::from_bits(128), data_layout.float128_align),
+                Primitive::Pointer(address_space) => (
+                    data_layout.pointer_size(),
+                    data_layout.pointer_align(address_space),
+                ),
+            };
+            (size, align, BackendRepr::Scalar(primitive))
+        };
+
+        let (size, align, backend_repr) = match ty {
+            LirTy::I8 => scalar(Primitive::I8),
+            LirTy::I16 => scalar(Primitive::I16),
+            LirTy::I32 => scalar(Primitive::I32),
+            LirTy::I64 => scalar(Primitive::I64),
+            LirTy::I128 => scalar(Primitive::I128),
+            LirTy::Metadata => unimplemented!("Metadata type layout not implemented"),
+        };
+
         TyAndLayout {
             ty,
             layout: Layout {
-                size: Size::from_bits(32),
-                align: AbiAndPrefAlign::new(4, 4),
-                backend_repr: BackendRepr::Scalar(Primitive::I32),
+                size,
+                align,
+                backend_repr,
             },
         }
+        // HARDCODE FOR TESTING an integer type
+        // TyAndLayout {
+        //     ty,
+        //     layout: Layout {
+        //         size: Size::from_bits(32),
+        //         align: AbiAndPrefAlign::new(4, 4),
+        //         backend_repr: BackendRepr::Scalar(Primitive::I32),
+        //     },
+        // }
     }
 }

--- a/compiler/tidec_lir/src/layout_ctx.rs
+++ b/compiler/tidec_lir/src/layout_ctx.rs
@@ -60,14 +60,5 @@ impl<'a> LayoutCtx<'a> {
                 backend_repr,
             },
         }
-        // HARDCODE FOR TESTING an integer type
-        // TyAndLayout {
-        //     ty,
-        //     layout: Layout {
-        //         size: Size::from_bits(32),
-        //         align: AbiAndPrefAlign::new(4, 4),
-        //         backend_repr: BackendRepr::Scalar(Primitive::I32),
-        //     },
-        // }
     }
 }

--- a/compiler/tidec_lir/src/lir.rs
+++ b/compiler/tidec_lir/src/lir.rs
@@ -282,6 +282,7 @@ pub struct LirUnit {
 pub enum EmitKind {
     Object,
     Assembly,
+    LlvmIr,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
# Summary 

This PR implements the `layout_of` query to obtain the `DataLayout` for a given scalar type.