### PR TITLE
CI: ensure LLVM cache is saved even if build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           path: ${{ env.LLVM_INSTALL_PATH }}
           key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ env.LLVM_BRANCH }}
+        if: always()
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # The Tide Compiler
 
-`Tide` is a research compiler that aims to _lower_ the backend-agnostic `Tide` intermediate representation (TIR) to various target-specific backends, such as LLVM or native assembly.
+`Tide` is a research compiler that aims to _lower_ the backend-agnostic `Tide` intermediate representation (TIR) to various target-specific backends (e.g., LLVM) or native assembly.
 The main goal of `Tide` is to provide a fast and adaptable compiler back-end framework that can be easily extended to support new target architectures and optimizations.

--- a/compiler/tidec/src/main.rs
+++ b/compiler/tidec/src/main.rs
@@ -4,13 +4,13 @@ use std::num::NonZero;
 use tidec_abi::target::BackendKind;
 use tidec_codegen_llvm::entry::llvm_codegen_lir_unit;
 use tidec_tir::basic_blocks::BasicBlockData;
+use tidec_tir::syntax::{
+    ConstOperand, ConstScalar, ConstValue, LocalData, Place, RValue, RawScalarValue, Statement,
+    Terminator, TirTy, RETURN_LOCAL,
+};
 use tidec_tir::tir::{
     CallConv, DefId, EmitKind, Linkage, TirBody, TirBodyKind, TirBodyMetadata, TirCtx, TirItemKind,
     TirUnit, TirUnitMetadata, UnnamedAddress, Visibility,
-};
-use tidec_tir::syntax::{
-    ConstOperand, ConstScalar, ConstValue, TirTy, LocalData, Place, RValue, RawScalarValue,
-    Statement, Terminator, RETURN_LOCAL,
 };
 use tidec_utils::index_vec::IdxVec;
 use tracing::debug;

--- a/compiler/tidec_codegen_llvm/src/context.rs
+++ b/compiler/tidec_codegen_llvm/src/context.rs
@@ -27,8 +27,8 @@ use tidec_codegen_ssa::traits::{
     BuilderMethods, CodegenBackend, CodegenBackendTypes, CodegenMethods, DefineCodegenMethods,
     FnAbiOf, LayoutOf, PreDefineCodegenMethods,
 };
+use tidec_tir::syntax::{Local, LocalData, TirTy, RETURN_LOCAL};
 use tidec_tir::tir::{DefId, EmitKind, TirBody, TirBodyMetadata, TirCtx, TirUnit};
-use tidec_tir::syntax::{TirTy, Local, LocalData, RETURN_LOCAL};
 
 // TODO: Add filelds from rustc/compiler/rustc_codegen_llvm/src/context.rs
 pub struct CodegenCtx<'ll> {

--- a/compiler/tidec_codegen_ssa/src/entry.rs
+++ b/compiler/tidec_codegen_ssa/src/entry.rs
@@ -5,8 +5,8 @@ use crate::{
 use tidec_abi::calling_convention::function::{FnAbi, PassMode};
 use tidec_tir::{
     basic_blocks::{BasicBlock, BasicBlockData},
+    syntax::{Local, RETURN_LOCAL, RValue, Statement, Terminator, TirTy},
     tir::TirBody,
-    syntax::{TirTy, Local, RETURN_LOCAL, RValue, Statement, Terminator},
 };
 use tidec_utils::index_vec::IdxVec;
 use tracing::{debug, info, instrument};

--- a/compiler/tidec_codegen_ssa/src/lir.rs
+++ b/compiler/tidec_codegen_ssa/src/lir.rs
@@ -11,8 +11,8 @@ use tidec_abi::{
 use tidec_tir::basic_blocks::ENTRY_BLOCK;
 use tidec_tir::syntax::ConstValue;
 use tidec_tir::{
+    syntax::{Local, LocalData, TirTy},
     tir::TirBody,
-    syntax::{TirTy, Local, LocalData},
 };
 use tidec_utils::index_vec::IdxVec;
 use tracing::{debug, instrument};

--- a/compiler/tidec_codegen_ssa/src/traits.rs
+++ b/compiler/tidec_codegen_ssa/src/traits.rs
@@ -4,8 +4,8 @@ use tidec_abi::{
     size_and_align::{Align, Size},
 };
 use tidec_tir::{
+    syntax::{ConstScalar, Local, LocalData, TirTy},
     tir::{TirBody, TirBodyMetadata, TirCtx, TirUnit},
-    syntax::{ConstScalar, TirTy, Local, LocalData},
 };
 use tidec_utils::index_vec::IdxVec;
 

--- a/compiler/tidec_tir/src/layout_ctx.rs
+++ b/compiler/tidec_tir/src/layout_ctx.rs
@@ -1,4 +1,4 @@
-use crate::{tir::TirCtx, syntax::TirTy};
+use crate::{syntax::TirTy, tir::TirCtx};
 use tidec_abi::{
     layout::{BackendRepr, Layout, Primitive, TyAndLayout},
     size_and_align::{AbiAndPrefAlign, Size},

--- a/compiler/tidec_tir/src/lib.rs
+++ b/compiler/tidec_tir/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod basic_blocks;
 pub mod layout_ctx;
-pub mod tir;
 pub mod syntax;
+pub mod tir;

--- a/compiler/tidec_tir/src/tir.rs
+++ b/compiler/tidec_tir/src/tir.rs
@@ -1,7 +1,7 @@
 use crate::{
     basic_blocks::{BasicBlock, BasicBlockData},
     layout_ctx::LayoutCtx,
-    syntax::{Body, TirTy, Local, LocalData},
+    syntax::{Body, Local, LocalData, TirTy},
 };
 use tidec_abi::{
     layout::TyAndLayout,


### PR DESCRIPTION
# Summary

- Cargo fmt
- Fix README
- Ensure LLVM cache is saved even if build fails