### PR TITLE
Add BinaryOp support with scalar operations

### DIFF
--- a/compiler/tidec_codegen_llvm/src/builder.rs
+++ b/compiler/tidec_codegen_llvm/src/builder.rs
@@ -208,6 +208,108 @@ impl<'a, 'll> BuilderMethods<'a, 'll> for CodegenBuilder<'a, 'll> {
             .into()
     }
 
+    fn build_fadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_float_type() && rhs.get_type().is_float_type());
+        self.ll_builder
+            .build_float_add(lhs.into_float_value(), rhs.into_float_value(), "fadd")
+            .unwrap()
+            .into()
+    }
+
+    fn build_add(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        self.ll_builder
+            .build_int_add(lhs.into_int_value(), rhs.into_int_value(), "add")
+            .unwrap()
+            .into()
+    }
+
+    fn build_sadd_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        Self::build_add(self, lhs, rhs)
+    }
+
+    fn build_uadd_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        Self::build_add(self, lhs, rhs)
+    }
+
+    fn build_fsub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_float_type() && rhs.get_type().is_float_type());
+        self.ll_builder
+            .build_float_sub(lhs.into_float_value(), rhs.into_float_value(), "fsub")
+            .unwrap()
+            .into()
+    }
+
+    fn build_sub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        self.ll_builder
+            .build_int_sub(lhs.into_int_value(), rhs.into_int_value(), "sub")
+            .unwrap()
+            .into()
+    }
+
+    fn build_ssub_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        Self::build_sub(self, lhs, rhs)
+    }
+
+    fn build_usub_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        Self::build_sub(self, lhs, rhs)
+    }
+
+    fn build_fmul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_float_type() && rhs.get_type().is_float_type());
+        self.ll_builder
+            .build_float_mul(lhs.into_float_value(), rhs.into_float_value(), "fmul")
+            .unwrap()
+            .into()
+    }
+
+    fn build_mul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        self.ll_builder
+            .build_int_mul(lhs.into_int_value(), rhs.into_int_value(), "mul")
+            .unwrap()
+            .into()
+    }
+
+    fn build_smul_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        Self::build_mul(self, lhs, rhs)
+    }
+
+    fn build_umul_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        Self::build_mul(self, lhs, rhs)
+    }
+
+    fn build_fdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_float_type() && rhs.get_type().is_float_type());
+        self.ll_builder
+            .build_float_div(lhs.into_float_value(), rhs.into_float_value(), "fdiv")
+            .unwrap()
+            .into()
+    }
+
+    fn build_sdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        self.ll_builder
+            .build_int_signed_div(lhs.into_int_value(), rhs.into_int_value(), "sdiv")
+            .unwrap()
+            .into()
+    }
+
+    fn build_udiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        assert!(lhs.get_type().is_int_type() && rhs.get_type().is_int_type());
+        self.ll_builder
+            .build_int_unsigned_div(lhs.into_int_value(), rhs.into_int_value(), "udiv")
+            .unwrap()
+            .into()
+    }
+
     fn const_scalar_to_backend_value(
         &self,
         const_scalar: ConstScalar,

--- a/compiler/tidec_codegen_llvm/src/context.rs
+++ b/compiler/tidec_codegen_llvm/src/context.rs
@@ -214,7 +214,7 @@ impl<'ll> CodegenMethods<'ll> for CodegenCtx<'ll> {
         }
     }
 
-    fn lir_ctx(&self) -> &TirCtx {
+    fn tir_ctx(&self) -> &TirCtx {
         &self.lir_ctx
     }
 
@@ -263,7 +263,7 @@ impl<'ll> CodegenMethods<'ll> for CodegenCtx<'ll> {
                 .expect("Failed to create target machine")
         };
 
-        match self.lir_ctx().emit_kind() {
+        match self.tir_ctx().emit_kind() {
             EmitKind::Object => {
                 let target_machine = target_machine();
                 let obj_path = format!("{}.o", self.ll_module.get_name().to_str().unwrap());

--- a/compiler/tidec_codegen_ssa/src/tir.rs
+++ b/compiler/tidec_codegen_ssa/src/tir.rs
@@ -231,7 +231,7 @@ pub fn codegen_lir_body<'a, 'be, B: BuilderMethods<'a, 'be>>(
     ctx: &'a B::CodegenCtx,
     lir_body: &'a TirBody,
 ) {
-    let fn_abi = ctx.fn_abi_of(ctx.lir_ctx(), &lir_body.ret_and_args);
+    let fn_abi = ctx.fn_abi_of(ctx.tir_ctx(), &lir_body.ret_and_args);
     let fn_value = ctx.get_or_define_fn(&lir_body.metadata, &lir_body.ret_and_args);
     let entry_bb = B::append_basic_block(ctx, fn_value, "entry");
     let mut start_builder = B::build(ctx, entry_bb);

--- a/compiler/tidec_codegen_ssa/src/traits.rs
+++ b/compiler/tidec_codegen_ssa/src/traits.rs
@@ -166,9 +166,38 @@ pub trait BuilderMethods<'a, 'be>: Sized + CodegenBackendTypes {
 
     /// Build a floating-point negation instruction for the given value.
     fn build_fneg(&mut self, val: Self::Value) -> Self::Value;
-
     /// Build an integer negation instruction for the given value.
     fn build_neg(&self, val: Self::Value) -> Self::Value;
+    /// Build a floating-point addition instruction for the given values.
+    fn build_fadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build an integer addition instruction for the given values.
+    fn build_add(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build a signed integer addition instruction for the given values, with undefined behavior on overflow.
+    fn build_sadd_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build an unsigned integer addition instruction for the given values, with undefined behavior on overflow.
+    fn build_uadd_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build a floating-point subtraction instruction for the given values.
+    fn build_fsub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build an integer subtraction instruction for the given values.
+    fn build_sub(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build a signed integer subtraction instruction for the given values, with undefined behavior on overflow.
+    fn build_ssub_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build an unsigned integer subtraction instruction for the given values, with undefined behavior on overflow.
+    fn build_usub_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build a floating-point multiplication instruction for the given values.
+    fn build_fmul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build an integer multiplication instruction for the given values.
+    fn build_mul(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build a signed integer multiplication instruction for the given values, with undefined behavior on overflow.
+    fn build_smul_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build an unsigned integer multiplication instruction for the given values, with undefined behavior on overflow.
+    fn build_umul_unchecked(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build a floating-point division instruction for the given values.
+    fn build_fdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build a signed integer division instruction for the given values.
+    fn build_sdiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
+    /// Build an unsigned integer division instruction for the given values.
+    fn build_udiv(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;    
 
     /// Build a store instruction to store the given value to the given place reference.
     /// This is used to store a value to memory.

--- a/compiler/tidec_codegen_ssa/src/traits.rs
+++ b/compiler/tidec_codegen_ssa/src/traits.rs
@@ -93,7 +93,7 @@ pub trait CodegenMethods<'be>:
     fn new(lir_ty_ctx: TirCtx, context: &'be Self::Context, module: Self::Module) -> Self;
 
     /// Return the TIR type context associated with this codegen context.
-    fn lir_ctx(&self) -> &TirCtx;
+    fn tir_ctx(&self) -> &TirCtx;
 
     /// Compile the given TIR unit.
     fn compile_lir_unit<'a, B: BuilderMethods<'a, 'be>>(&self, lir_unit: TirUnit);


### PR DESCRIPTION
This PR introduces binary operations support to the TIR (Typed Intermediate Representation) and implements codegen for scalar binary operations, along with cleanup of naming conventions.

### Changes

#### Commit 1: Add BinaryOp to TIR and implement support for scalar binary operations in codegen
- **TIR Syntax (`tidec_tir/src/syntax.rs`)**: Add `BinaryOp` enum with variants for `Add`, `AddUnchecked`, `Sub`, `SubUnchecked`, `Mul`, `MulUnchecked`, and `Div`
- **SSA Traits (`tidec_codegen_ssa/src/traits.rs`)**: Add builder methods for all binary operations including checked/unchecked variants for integer arithmetic
- **SSA Entry (`tidec_codegen_ssa/src/entry.rs`)**: Implement `codegen_scalar_binary_op` method with proper floating-point vs integer operation handling
- **LLVM Builder (`tidec_codegen_llvm/src/builder.rs`)**: Implement all binary operation builder methods with proper LLVM instruction generation

#### Commit 2: Rename lir_ctx to tir_ctx in codegen traits and usage  
- Update naming consistency from LIR (Low-level IR) to TIR (Typed IR) across codegen context references
- Affects `tidec_codegen_llvm/src/context.rs`, `tidec_codegen_ssa/src/tir.rs`, and `tidec_codegen_ssa/src/traits.rs`

### Technical Details

The implementation provides:
- **Type-aware operations**: Proper handling of floating-point vs integer arithmetic
- **Signedness support**: Separate signed/unsigned operations where applicable  
- **Overflow variants**: Both checked operations (default) and explicit