### PR TITLE
Implement TIR builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     # tidy-alphabetical-start
     "compiler/tidec",
     "compiler/tidec_abi",
+    "compiler/tidec_builder",
     "compiler/tidec_codegen_llvm",
     "compiler/tidec_codegen_ssa",
     "compiler/tidec_log",

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 [![CI](https://github.com/FedericoBruzzone/tide/workflows/CI/badge.svg)](https://github.com/FedericoBruzzone/tide/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/FedericoBruzzone/tide#license)
 
-`Tide` is a research compiler that uses its backend-agnostic intermediate representation (TIR) as a central abstraction. From the TIR, `Tide` is currently able to _lower_ it into existing backend-specific IRs (e.g., LLVM IR).
+`Tide` is a research compiler that uses its backend-agnostic non-textual intermediate representation (TIR) as a central abstraction. From the TIR, `Tide` is currently able to _lower_ it into existing backend-specific IRs (e.g., LLVM IR).
 
 Future directions include the ability to (i) _lower_ TIR into other backend-specific IRs (e.g., WebAssembly), (ii) directly _generate machine_ code for target architectures (e.g., x86-64), or (iii) _interpret_ TIR for rapid prototyping and experimentation.

--- a/compiler/tidec/Cargo.toml
+++ b/compiler/tidec/Cargo.toml
@@ -5,14 +5,15 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
-# inkwell = { version = "0.5.0", features = ["llvm18-0"] } 
+# inkwell = { version = "0.5.0", features = ["llvm18-0"] }
 # inkwell = { git = "https://github.com/stevefan1999-personal/inkwell", rev = "0732f8dcb7b2b7f8edc25895d6dbd37ba439672c", features = [ "llvm19-1" ] }
 # inkwell = { git = "https://github.com/TheDan64/inkwell", rev = "279ef78b3507a431e48767748c2335aef26b7d9f", features = [ "llvm18-1" ] }
 inkwell = { git = "https://github.com/TheDan64/inkwell", rev = "279ef78b3507a431e48767748c2335aef26b7d9f", features = [ "llvm20-1" ] }
 tidec_abi = { path = "../tidec_abi" }
+tidec_builder = { path = "../tidec_builder" }
 tidec_codegen_llvm = { path = "../tidec_codegen_llvm" }
-tidec_log = { path = "../tidec_log" }
 tidec_codegen_ssa = { path = "../tidec_codegen_ssa" }
+tidec_log = { path = "../tidec_log" }
 tidec_tir = { path = "../tidec_tir" }
 tidec_utils = { path = "../tidec_utils" }
 tracing = "0.1.41"

--- a/compiler/tidec/src/main.rs
+++ b/compiler/tidec/src/main.rs
@@ -1,8 +1,10 @@
 use std::num::NonZero;
 // #[macro_use] extern crate tidec_utils;
 //
+//
 use tidec_abi::size_and_align::Size;
 use tidec_abi::target::{BackendKind, TirTarget};
+use tidec_builder::BuilderCtx;
 use tidec_codegen_llvm::entry::llvm_codegen_lir_unit;
 
 use tidec_tir::body::{
@@ -14,7 +16,6 @@ use tidec_tir::syntax::{
     BasicBlock, BasicBlockData, ConstOperand, ConstScalar, ConstValue, Local, LocalData, Operand,
     Place, RValue, RawScalarValue, Statement, Terminator, UnaryOp, RETURN_LOCAL,
 };
-use tidec_tir::ty::{Mutability, TirTy};
 use tidec_utils::idx::Idx;
 use tidec_utils::index_vec::IdxVec;
 use tracing::{debug, instrument};
@@ -32,10 +33,11 @@ use tracing::{debug, instrument};
 ///   ld main.o -o a.out -lSystem -syslibroot `xcrun --show-sdk-path` \
 ///   ./a.out; echo $?
 fn example_printf<'a>(tir_ctx: &TirCtx<'a>) -> TirUnit<'a> {
-    // Intern the pointer type for i8 (for printf's char* parameter)
-    let i8_ty = tir_ctx.intern_ty(TirTy::<TirCtx>::I8);
-    let ptr_i8_ty = tir_ctx.intern_ty(TirTy::RawPtr(i8_ty, Mutability::Imm));
-    let i32_ty = tir_ctx.intern_ty(TirTy::<TirCtx>::I32);
+    // Use BuilderCtx to construct all TIR types
+    let builder_ctx = BuilderCtx::new(*tir_ctx);
+    let i8_ty = builder_ctx.i8();
+    let ptr_i8_ty = builder_ctx.ptr_imm(i8_ty);
+    let i32_ty = builder_ctx.i32();
 
     // Declare printf as an external function
     // int printf(const char* format, ...)
@@ -265,10 +267,14 @@ fn example1<'a>(tir_ctx: &TirCtx<'a>) -> TirUnit<'a> {
         is_varargs: false,
         is_declaration: false,
     };
+
+    let builder_ctx = BuilderCtx::new(*tir_ctx);
+    let i32_ty = builder_ctx.i32();
+
     let lir_bodies = IdxVec::from_raw(vec![TirBody {
         metadata: lir_body_metadata,
         ret_and_args: IdxVec::from_raw(vec![LocalData {
-            ty: tir_ctx.intern_ty(TirTy::<TirCtx>::I32),
+            ty: i32_ty,
             mutable: false,
         }]),
         locals: IdxVec::new(),
@@ -285,7 +291,7 @@ fn example1<'a>(tir_ctx: &TirCtx<'a>) -> TirUnit<'a> {
                             data: 10u128,
                             size: NonZero::new(4).unwrap(), // 4 bytes for i32
                         })),
-                        tir_ctx.intern_ty(TirTy::<TirCtx>::I32),
+                        i32_ty,
                     )),
                 ),
             )))],

--- a/compiler/tidec/tests/printf_hello.rs
+++ b/compiler/tidec/tests/printf_hello.rs
@@ -6,6 +6,7 @@ use std::num::NonZero;
 
 use common::{TestContext, TestRunner};
 use tidec_abi::size_and_align::Size;
+use tidec_builder::BuilderCtx;
 use tidec_tir::body::{
     CallConv, DefId, Linkage, TirBody, TirBodyKind, TirBodyMetadata, TirItemKind, TirUnit,
     TirUnitMetadata, UnnamedAddress, Visibility,
@@ -15,15 +16,15 @@ use tidec_tir::syntax::{
     BasicBlock, BasicBlockData, ConstOperand, ConstScalar, ConstValue, Local, LocalData, Operand,
     Place, RValue, RawScalarValue, Statement, Terminator, UnaryOp, RETURN_LOCAL,
 };
-use tidec_tir::ty::{Mutability, TirTy};
 use tidec_utils::idx::Idx;
 use tidec_utils::index_vec::IdxVec;
 
 /// Create a program that calls printf and returns 0.
 fn create_printf_hello<'a>(tir_ctx: &TirCtx<'a>) -> TirUnit<'a> {
-    let i8_ty = tir_ctx.intern_ty(TirTy::<TirCtx>::I8);
-    let ptr_i8_ty = tir_ctx.intern_ty(TirTy::RawPtr(i8_ty, Mutability::Imm));
-    let i32_ty = tir_ctx.intern_ty(TirTy::<TirCtx>::I32);
+    let builder_ctx = BuilderCtx::new(*tir_ctx);
+    let i8_ty = builder_ctx.i8();
+    let ptr_i8_ty = builder_ctx.ptr_imm(i8_ty);
+    let i32_ty = builder_ctx.i32();
 
     // Declare printf
     let printf_def_id = DefId(0);

--- a/compiler/tidec/tests/return_255.rs
+++ b/compiler/tidec/tests/return_255.rs
@@ -5,6 +5,7 @@ mod common;
 use std::num::NonZero;
 
 use common::{TestContext, TestRunner};
+use tidec_builder::BuilderCtx;
 use tidec_tir::body::{
     CallConv, DefId, Linkage, TirBody, TirBodyKind, TirBodyMetadata, TirItemKind, TirUnit,
     TirUnitMetadata, UnnamedAddress, Visibility,
@@ -14,12 +15,12 @@ use tidec_tir::syntax::{
     BasicBlockData, ConstOperand, ConstScalar, ConstValue, LocalData, Operand, Place, RValue,
     RawScalarValue, Statement, Terminator, UnaryOp, RETURN_LOCAL,
 };
-use tidec_tir::ty::TirTy;
 use tidec_utils::index_vec::IdxVec;
 
 /// Create a simple main function that returns 255.
 fn create_return_255<'a>(tir_ctx: &TirCtx<'a>) -> TirUnit<'a> {
-    let i32_ty = tir_ctx.intern_ty(TirTy::<TirCtx>::I32);
+    let builder_ctx = BuilderCtx::new(*tir_ctx);
+    let i32_ty = builder_ctx.i32();
 
     let main_metadata = TirBodyMetadata {
         def_id: DefId(0),

--- a/compiler/tidec/tests/return_42.rs
+++ b/compiler/tidec/tests/return_42.rs
@@ -5,6 +5,7 @@ mod common;
 use std::num::NonZero;
 
 use common::{TestContext, TestRunner};
+use tidec_builder::BuilderCtx;
 use tidec_tir::body::{
     CallConv, DefId, Linkage, TirBody, TirBodyKind, TirBodyMetadata, TirItemKind, TirUnit,
     TirUnitMetadata, UnnamedAddress, Visibility,
@@ -14,12 +15,12 @@ use tidec_tir::syntax::{
     BasicBlockData, ConstOperand, ConstScalar, ConstValue, LocalData, Operand, Place, RValue,
     RawScalarValue, Statement, Terminator, UnaryOp, RETURN_LOCAL,
 };
-use tidec_tir::ty::TirTy;
 use tidec_utils::index_vec::IdxVec;
 
 /// Create a simple main function that returns 42.
 fn create_return_42<'a>(tir_ctx: &TirCtx<'a>) -> TirUnit<'a> {
-    let i32_ty = tir_ctx.intern_ty(TirTy::<TirCtx>::I32);
+    let builder_ctx = BuilderCtx::new(*tir_ctx);
+    let i32_ty = builder_ctx.i32();
 
     let main_metadata = TirBodyMetadata {
         def_id: DefId(0),

--- a/compiler/tidec/tests/return_zero.rs
+++ b/compiler/tidec/tests/return_zero.rs
@@ -5,6 +5,7 @@ mod common;
 use std::num::NonZero;
 
 use common::{TestContext, TestRunner};
+use tidec_builder::BuilderCtx;
 use tidec_tir::body::{
     CallConv, DefId, Linkage, TirBody, TirBodyKind, TirBodyMetadata, TirItemKind, TirUnit,
     TirUnitMetadata, UnnamedAddress, Visibility,
@@ -14,12 +15,12 @@ use tidec_tir::syntax::{
     BasicBlockData, ConstOperand, ConstScalar, ConstValue, LocalData, Operand, Place, RValue,
     RawScalarValue, Statement, Terminator, UnaryOp, RETURN_LOCAL,
 };
-use tidec_tir::ty::TirTy;
 use tidec_utils::index_vec::IdxVec;
 
 /// Create a simple main function that returns 0.
 fn create_return_zero<'a>(tir_ctx: &TirCtx<'a>) -> TirUnit<'a> {
-    let i32_ty = tir_ctx.intern_ty(TirTy::<TirCtx>::I32);
+    let builder_ctx = BuilderCtx::new(*tir_ctx);
+    let i32_ty = builder_ctx.i32();
 
     let main_metadata = TirBodyMetadata {
         def_id: DefId(0),

--- a/compiler/tidec_builder/Cargo.toml
+++ b/compiler/tidec_builder/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tidec_builder"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# tidy-alphabetical-start
+tidec_abi = { path = "../tidec_abi" }
+tidec_tir = { path = "../tidec_tir" }
+tidec_utils = { path = "../tidec_utils" }
+tracing = "0.1.41"
+# tidy-alphabetical-end

--- a/compiler/tidec_builder/src/basic_block_builder.rs
+++ b/compiler/tidec_builder/src/basic_block_builder.rs
@@ -1,0 +1,260 @@
+//! Builder for a single basic block.
+//!
+//! A [`BasicBlockBuilder`] accumulates [`Statement`]s and is finalized by
+//! setting a [`Terminator`]. The result is a [`BasicBlockData`] that can be
+//! inserted into a function body via the [`FunctionBuilder`](crate::FunctionBuilder).
+
+use tidec_tir::syntax::{
+    AggregateKind, BasicBlockData, BinaryOp, CastKind, Operand, Place, RValue, Statement,
+    Terminator, UnaryOp,
+};
+use tidec_tir::ty::Mutability;
+use tidec_tir::TirTy;
+
+/// A builder for constructing a single [`BasicBlockData`].
+///
+/// Statements are appended in order via the various `push_*` helpers, and the
+/// block is finalized by calling [`build`](Self::build) with a [`Terminator`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let mut bb = BasicBlockBuilder::new();
+/// bb.push_assign(place, rvalue);
+/// let data = bb.build(Terminator::Return);
+/// ```
+pub struct BasicBlockBuilder<'ctx> {
+    statements: Vec<Statement<'ctx>>,
+}
+
+impl<'ctx> BasicBlockBuilder<'ctx> {
+    /// Create a new, empty basic-block builder.
+    pub fn new() -> Self {
+        Self {
+            statements: Vec::new(),
+        }
+    }
+
+    /// Create a new basic-block builder with pre-allocated capacity for
+    /// `capacity` statements.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            statements: Vec::with_capacity(capacity),
+        }
+    }
+
+    // ───────────────────────── Raw push ──────────────────────────
+
+    /// Push an arbitrary [`Statement`] to the block.
+    pub fn push_statement(&mut self, stmt: Statement<'ctx>) -> &mut Self {
+        self.statements.push(stmt);
+        self
+    }
+
+    // ───────────────────────── Assign helpers ────────────────────
+
+    /// Append an `Assign(place, rvalue)` statement.
+    pub fn push_assign(&mut self, place: Place<'ctx>, rvalue: RValue<'ctx>) -> &mut Self {
+        self.statements
+            .push(Statement::Assign(Box::new((place, rvalue))));
+        self
+    }
+
+    /// Append an assignment of an [`Operand`] to a [`Place`].
+    ///
+    /// This is a shorthand for `push_assign(place, RValue::Operand(operand))`.
+    pub fn push_assign_operand(&mut self, place: Place<'ctx>, operand: Operand<'ctx>) -> &mut Self {
+        self.push_assign(place, RValue::Operand(operand))
+    }
+
+    /// Append a unary-operation assignment: `place = unary_op(operand)`.
+    pub fn push_assign_unary_op(
+        &mut self,
+        place: Place<'ctx>,
+        op: UnaryOp,
+        operand: Operand<'ctx>,
+    ) -> &mut Self {
+        self.push_assign(place, RValue::UnaryOp(op, operand))
+    }
+
+    /// Append a binary-operation assignment: `place = lhs binop rhs`.
+    pub fn push_assign_binary_op(
+        &mut self,
+        place: Place<'ctx>,
+        op: BinaryOp,
+        lhs: Operand<'ctx>,
+        rhs: Operand<'ctx>,
+    ) -> &mut Self {
+        self.push_assign(place, RValue::BinaryOp(op, lhs, rhs))
+    }
+
+    /// Append a cast assignment: `place = cast(operand) as ty`.
+    pub fn push_assign_cast(
+        &mut self,
+        place: Place<'ctx>,
+        kind: CastKind,
+        operand: Operand<'ctx>,
+        ty: TirTy<'ctx>,
+    ) -> &mut Self {
+        self.push_assign(place, RValue::Cast(kind, operand, ty))
+    }
+
+    /// Append an aggregate construction assignment:
+    /// `place = AggregateKind(operands…)`.
+    pub fn push_assign_aggregate(
+        &mut self,
+        place: Place<'ctx>,
+        kind: AggregateKind<'ctx>,
+        operands: Vec<Operand<'ctx>>,
+    ) -> &mut Self {
+        self.push_assign(place, RValue::Aggregate(kind, operands))
+    }
+
+    /// Append an address-of assignment: `place = &[mut] source`.
+    pub fn push_assign_address_of(
+        &mut self,
+        place: Place<'ctx>,
+        mutability: Mutability,
+        source: Place<'ctx>,
+    ) -> &mut Self {
+        self.push_assign(place, RValue::AddressOf(mutability, source))
+    }
+
+    // ───────────────────────── Introspection ─────────────────────
+
+    /// Returns the number of statements already pushed.
+    pub fn len(&self) -> usize {
+        self.statements.len()
+    }
+
+    /// Returns `true` if no statements have been pushed yet.
+    pub fn is_empty(&self) -> bool {
+        self.statements.is_empty()
+    }
+
+    // ───────────────────────── Finalization ──────────────────────
+
+    /// Finalize the block with the given terminator and return the completed
+    /// [`BasicBlockData`].
+    ///
+    /// The builder is consumed by this call.
+    pub fn build(self, terminator: Terminator<'ctx>) -> BasicBlockData<'ctx> {
+        BasicBlockData {
+            statements: self.statements,
+            terminator,
+        }
+    }
+}
+
+impl<'ctx> Default for BasicBlockBuilder<'ctx> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidec_tir::syntax::{BasicBlock, Local, SwitchTargets, RETURN_LOCAL};
+    use tidec_utils::idx::Idx;
+
+    #[test]
+    fn empty_block_with_return() {
+        let bb = BasicBlockBuilder::new();
+        let data = bb.build(Terminator::Return);
+        assert!(data.statements.is_empty());
+        assert!(matches!(data.terminator, Terminator::Return));
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let bb = BasicBlockBuilder::<'_>::default();
+        assert!(bb.is_empty());
+        assert_eq!(bb.len(), 0);
+    }
+
+    #[test]
+    fn push_assign_increases_length() {
+        let mut bb = BasicBlockBuilder::new();
+        assert_eq!(bb.len(), 0);
+
+        let place: Place<'_> = Place::from(Local::new(1));
+        let operand = Operand::Use(Place::from(Local::new(2)));
+        bb.push_assign_operand(place, operand);
+        assert_eq!(bb.len(), 1);
+    }
+
+    #[test]
+    fn build_with_goto_terminator() {
+        let mut bb = BasicBlockBuilder::new();
+        let place: Place<'_> = Place::from(RETURN_LOCAL);
+        let operand = Operand::Use(Place::from(Local::new(1)));
+        bb.push_assign_operand(place, operand);
+
+        let target = BasicBlock::new(1);
+        let data = bb.build(Terminator::Goto { target });
+
+        assert_eq!(data.statements.len(), 1);
+        assert!(matches!(
+            data.terminator,
+            Terminator::Goto { target: t } if t == BasicBlock::new(1)
+        ));
+    }
+
+    #[test]
+    fn with_capacity_starts_empty() {
+        let bb = BasicBlockBuilder::<'_>::with_capacity(16);
+        assert!(bb.is_empty());
+    }
+
+    #[test]
+    fn push_statement_raw() {
+        let mut bb = BasicBlockBuilder::new();
+        let place: Place<'_> = Place::from(Local::new(0));
+        let rvalue = RValue::Operand(Operand::Use(Place::from(Local::new(1))));
+        let stmt = Statement::Assign(Box::new((place, rvalue)));
+        bb.push_statement(stmt);
+        assert_eq!(bb.len(), 1);
+    }
+
+    #[test]
+    fn multiple_statements_preserve_order() {
+        let mut bb = BasicBlockBuilder::new();
+
+        // Push three assigns targeting locals 0, 1, 2.
+        for i in 0..3 {
+            let place: Place<'_> = Place::from(Local::new(i));
+            let rvalue = RValue::Operand(Operand::Use(Place::from(Local::new(i + 10))));
+            bb.push_assign(place, rvalue);
+        }
+
+        let data = bb.build(Terminator::Unreachable);
+        assert_eq!(data.statements.len(), 3);
+        assert!(matches!(data.terminator, Terminator::Unreachable));
+    }
+
+    #[test]
+    fn build_with_switch_int_terminator() {
+        let bb = BasicBlockBuilder::new();
+        let discr = Operand::Use(Place::from(Local::new(5)));
+        let targets = SwitchTargets::if_then(BasicBlock::new(1), BasicBlock::new(2));
+        let data = bb.build(Terminator::SwitchInt { discr, targets });
+
+        assert!(data.statements.is_empty());
+        assert!(matches!(data.terminator, Terminator::SwitchInt { .. }));
+    }
+
+    #[test]
+    fn chaining_api() {
+        let data = {
+            let mut bb = BasicBlockBuilder::new();
+            let p0: Place<'_> = Place::from(Local::new(0));
+            let p1: Place<'_> = Place::from(Local::new(1));
+            let op = Operand::Use(Place::from(Local::new(2)));
+            bb.push_assign_operand(p0, op.clone())
+                .push_assign_unary_op(p1, UnaryOp::Neg, op);
+            bb.build(Terminator::Return)
+        };
+        assert_eq!(data.statements.len(), 2);
+    }
+}

--- a/compiler/tidec_builder/src/builder_ctx.rs
+++ b/compiler/tidec_builder/src/builder_ctx.rs
@@ -1,0 +1,512 @@
+//! Builder context for ergonomic TIR construction.
+//!
+//! [`BuilderCtx`] encapsulates the complexity of arena allocation and interning,
+//! providing a clean API for creating types, allocations, and other TIR entities
+//! without exposing the underlying interning machinery.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use tidec_builder::BuilderCtx;
+//!
+//! BuilderCtx::with_default(|ctx| {
+//!     // Create types without manual interning
+//!     let i32_ty = ctx.i32();
+//!     let f64_ty = ctx.f64();
+//!     let ptr_ty = ctx.ptr_imm(i32_ty);
+//!     let struct_ty = ctx.struct_ty(&[i32_ty, f64_ty], false);
+//!
+//!     // Intern allocations
+//!     let str_alloc = ctx.intern_c_str("hello");
+//!     let bytes_alloc = ctx.intern_bytes(&[1, 2, 3, 4]);
+//!
+//!     // Use with builders
+//!     let mut fb = ctx.function_builder(metadata);
+//!     fb.declare_ret(i32_ty, false);
+//!     // ...
+//! });
+//! ```
+
+use tidec_abi::layout::TyAndLayout;
+use tidec_abi::target::{BackendKind, TirTarget};
+use tidec_tir::alloc::AllocId;
+use tidec_tir::body::{DefId, GlobalId};
+use tidec_tir::ctx::{EmitKind, InternCtx, TirArena, TirArgs, TirCtx};
+use tidec_tir::ty::{self, Mutability};
+use tidec_tir::{TirAllocation, TirTy, TirTypeList};
+
+use crate::{FunctionBuilder, UnitBuilder};
+use tidec_tir::body::TirBodyMetadata;
+
+/// A builder context that manages TIR construction with automatic interning.
+///
+/// This struct encapsulates the arena, interning context, and TIR context,
+/// providing ergonomic methods for creating types and interning allocations
+/// without exposing the underlying complexity to the user.
+///
+/// # Lifetime
+///
+/// The `'ctx` lifetime parameter represents the lifetime of the arena and all
+/// interned values. All types and allocations created through this context
+/// live for `'ctx`.
+pub struct BuilderCtx<'ctx> {
+    ctx: TirCtx<'ctx>,
+}
+
+impl<'ctx> BuilderCtx<'ctx> {
+    /// Create a new `BuilderCtx` from existing components.
+    ///
+    /// For most use cases, prefer [`with_default`](Self::with_default) or
+    /// [`with_target`](Self::with_target) which handle arena setup automatically.
+    pub fn new(ctx: TirCtx<'ctx>) -> Self {
+        Self { ctx }
+    }
+
+    /// Run a closure with a default `BuilderCtx`.
+    ///
+    /// This is the simplest way to use the builder API. It creates an arena
+    /// and context with default settings (LLVM backend, object emission).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// BuilderCtx::with_default(|ctx| {
+    ///     let i32_ty = ctx.i32();
+    ///     // ... build your TIR ...
+    /// });
+    /// ```
+    pub fn with_default<F, R>(f: F) -> R
+    where
+        F: for<'a> FnOnce(BuilderCtx<'a>) -> R,
+    {
+        Self::with_target(BackendKind::Llvm, EmitKind::Object, f)
+    }
+
+    /// Run a closure with a `BuilderCtx` configured for the specified target.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// BuilderCtx::with_target(BackendKind::Llvm, EmitKind::LlvmIr, |ctx| {
+    ///     let i32_ty = ctx.i32();
+    ///     // ... build your TIR ...
+    /// });
+    /// ```
+    pub fn with_target<F, R>(backend: BackendKind, emit: EmitKind, f: F) -> R
+    where
+        F: for<'a> FnOnce(BuilderCtx<'a>) -> R,
+    {
+        let target = TirTarget::new(backend);
+        let args = TirArgs { emit_kind: emit };
+        let arena = TirArena::default();
+        let intern_ctx = InternCtx::new(&arena);
+        let tir_ctx = TirCtx::new(&target, &args, &intern_ctx);
+        let builder_ctx = BuilderCtx::new(tir_ctx);
+        f(builder_ctx)
+    }
+
+    /// Returns a reference to the underlying `TirCtx`.
+    ///
+    /// This can be used when you need direct access to the TIR context,
+    /// for example to compute layouts or access target information.
+    pub fn tir_ctx(&self) -> &TirCtx<'ctx> {
+        &self.ctx
+    }
+
+    // =========================================================================
+    // Primitive types
+    // =========================================================================
+
+    /// Create the unit type `()`.
+    pub fn unit(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::Unit)
+    }
+
+    /// Create the boolean type.
+    pub fn bool(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::Bool)
+    }
+
+    /// Create the `i8` type.
+    pub fn i8(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::I8)
+    }
+
+    /// Create the `i16` type.
+    pub fn i16(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::I16)
+    }
+
+    /// Create the `i32` type.
+    pub fn i32(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::I32)
+    }
+
+    /// Create the `i64` type.
+    pub fn i64(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::I64)
+    }
+
+    /// Create the `i128` type.
+    pub fn i128(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::I128)
+    }
+
+    /// Create the `u8` type.
+    pub fn u8(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::U8)
+    }
+
+    /// Create the `u16` type.
+    pub fn u16(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::U16)
+    }
+
+    /// Create the `u32` type.
+    pub fn u32(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::U32)
+    }
+
+    /// Create the `u64` type.
+    pub fn u64(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::U64)
+    }
+
+    /// Create the `u128` type.
+    pub fn u128(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::U128)
+    }
+
+    /// Create the `f16` type.
+    pub fn f16(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::F16)
+    }
+
+    /// Create the `f32` type.
+    pub fn f32(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::F32)
+    }
+
+    /// Create the `f64` type.
+    pub fn f64(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::F64)
+    }
+
+    /// Create the `f128` type.
+    pub fn f128(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::F128)
+    }
+
+    /// Create the metadata type.
+    pub fn metadata(&self) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::Metadata)
+    }
+
+    // =========================================================================
+    // Composite types
+    // =========================================================================
+
+    /// Create an immutable raw pointer type (`*imm T`).
+    pub fn ptr_imm(&self, pointee: TirTy<'ctx>) -> TirTy<'ctx> {
+        self.ctx
+            .intern_ty(ty::TirTy::RawPtr(pointee, Mutability::Imm))
+    }
+
+    /// Create a mutable raw pointer type (`*mut T`).
+    pub fn ptr_mut(&self, pointee: TirTy<'ctx>) -> TirTy<'ctx> {
+        self.ctx
+            .intern_ty(ty::TirTy::RawPtr(pointee, Mutability::Mut))
+    }
+
+    /// Create a raw pointer type with explicit mutability.
+    pub fn ptr(&self, pointee: TirTy<'ctx>, mutability: Mutability) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::RawPtr(pointee, mutability))
+    }
+
+    /// Create a struct type from field types.
+    ///
+    /// # Arguments
+    ///
+    /// * `fields` - The types of the struct fields.
+    /// * `packed` - If `true`, the struct uses packed layout (no alignment padding).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let pair_ty = ctx.struct_ty(&[ctx.i32(), ctx.f64()], false);
+    /// ```
+    pub fn struct_ty(&self, fields: &[TirTy<'ctx>], packed: bool) -> TirTy<'ctx> {
+        let fields = self.ctx.intern_type_list(fields);
+        self.ctx.intern_ty(ty::TirTy::Struct { fields, packed })
+    }
+
+    /// Create a fixed-size array type.
+    ///
+    /// # Arguments
+    ///
+    /// * `element` - The element type.
+    /// * `len` - The number of elements.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let arr_ty = ctx.array(ctx.i32(), 10); // [i32; 10]
+    /// ```
+    pub fn array(&self, element: TirTy<'ctx>, len: u64) -> TirTy<'ctx> {
+        self.ctx.intern_ty(ty::TirTy::Array(element, len))
+    }
+
+    // =========================================================================
+    // Type list interning
+    // =========================================================================
+
+    /// Intern a list of types.
+    ///
+    /// This is useful for function signatures or other contexts where you need
+    /// a type list but not necessarily a struct type.
+    pub fn type_list(&self, types: &[TirTy<'ctx>]) -> TirTypeList<'ctx> {
+        self.ctx.intern_type_list(types)
+    }
+
+    // =========================================================================
+    // Allocation interning
+    // =========================================================================
+
+    /// Intern a C-string (null-terminated) and register it as a memory allocation.
+    ///
+    /// Returns the `AllocId` that can be used to reference this string in the TIR.
+    pub fn intern_c_str(&self, s: &str) -> AllocId {
+        self.ctx.intern_c_str(s)
+    }
+
+    /// Intern raw bytes and register them as a memory allocation.
+    ///
+    /// Returns the `AllocId` that can be used to reference these bytes in the TIR.
+    pub fn intern_bytes(&self, bytes: &[u8]) -> AllocId {
+        self.ctx.intern_bytes(bytes)
+    }
+
+    /// Register a function as a global allocation.
+    ///
+    /// Returns the `AllocId` for the function reference.
+    pub fn intern_fn(&self, def_id: DefId) -> AllocId {
+        self.ctx.intern_fn(def_id)
+    }
+
+    /// Register a global variable (static) as a global allocation.
+    ///
+    /// Returns the `AllocId` that can be used to reference this global.
+    pub fn intern_static(&self, global_id: GlobalId) -> AllocId {
+        self.ctx.intern_static(global_id)
+    }
+
+    /// Intern an allocation directly.
+    ///
+    /// For most use cases, prefer [`intern_c_str`](Self::intern_c_str) or
+    /// [`intern_bytes`](Self::intern_bytes).
+    pub fn intern_alloc(&self, alloc: tidec_tir::alloc::Allocation) -> TirAllocation<'ctx> {
+        self.ctx.intern_alloc(alloc)
+    }
+
+    // =========================================================================
+    // Builder factory methods
+    // =========================================================================
+
+    /// Create a new function builder with the given metadata.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let mut fb = ctx.function_builder(metadata);
+    /// fb.declare_ret(ctx.i32(), false);
+    /// fb.declare_arg(ctx.i32(), false);
+    /// let entry = fb.create_block();
+    /// // ... build the function body ...
+    /// let body = fb.build();
+    /// ```
+    pub fn function_builder(&self, metadata: TirBodyMetadata) -> FunctionBuilder<'ctx> {
+        FunctionBuilder::new(metadata)
+    }
+
+    /// Create a new unit (module) builder with the given name.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let mut unit = ctx.unit_builder("my_module");
+    /// unit.add_body(my_function_body);
+    /// let tir_unit = unit.build();
+    /// ```
+    pub fn unit_builder(&self, name: impl Into<String>) -> UnitBuilder<'ctx> {
+        UnitBuilder::new(name)
+    }
+
+    // =========================================================================
+    // Target and layout information
+    // =========================================================================
+
+    /// Returns the target configuration.
+    pub fn target(&self) -> &TirTarget {
+        self.ctx.target()
+    }
+
+    /// Returns the backend kind (e.g., LLVM).
+    pub fn backend_kind(&self) -> &BackendKind {
+        self.ctx.backend_kind()
+    }
+
+    /// Returns the emit kind (e.g., Object, Assembly, LLVM IR).
+    pub fn emit_kind(&self) -> &EmitKind {
+        self.ctx.emit_kind()
+    }
+
+    /// Compute the layout of a type.
+    ///
+    /// This is useful for determining sizes, alignments, and field offsets.
+    pub fn layout_of(&self, ty: TirTy<'ctx>) -> TyAndLayout<'ctx, TirTy<'ctx>> {
+        self.ctx.layout_of(ty)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_types_are_interned() {
+        BuilderCtx::with_default(|ctx| {
+            let i32_a = ctx.i32();
+            let i32_b = ctx.i32();
+            assert_eq!(i32_a, i32_b, "Same primitive type should be deduplicated");
+
+            let f64_a = ctx.f64();
+            let f64_b = ctx.f64();
+            assert_eq!(f64_a, f64_b);
+
+            assert_ne!(i32_a, f64_a, "Different types should not be equal");
+        });
+    }
+
+    #[test]
+    fn pointer_types_are_interned() {
+        BuilderCtx::with_default(|ctx| {
+            let i32_ty = ctx.i32();
+            let ptr1 = ctx.ptr_imm(i32_ty);
+            let ptr2 = ctx.ptr_imm(i32_ty);
+            assert_eq!(ptr1, ptr2, "Same pointer type should be deduplicated");
+
+            let ptr_mut = ctx.ptr_mut(i32_ty);
+            assert_ne!(
+                ptr1, ptr_mut,
+                "Different mutability should produce different types"
+            );
+        });
+    }
+
+    #[test]
+    fn struct_types_are_created_correctly() {
+        BuilderCtx::with_default(|ctx| {
+            let i32_ty = ctx.i32();
+            let f64_ty = ctx.f64();
+            let struct_ty = ctx.struct_ty(&[i32_ty, f64_ty], false);
+
+            assert!(struct_ty.is_struct());
+        });
+    }
+
+    #[test]
+    fn array_types_are_created_correctly() {
+        BuilderCtx::with_default(|ctx| {
+            let i32_ty = ctx.i32();
+            let arr_ty = ctx.array(i32_ty, 10);
+
+            assert!(arr_ty.is_array());
+        });
+    }
+
+    #[test]
+    fn c_string_interning() {
+        BuilderCtx::with_default(|ctx| {
+            let alloc1 = ctx.intern_c_str("hello");
+            let alloc2 = ctx.intern_c_str("world");
+
+            // Different strings should get different alloc IDs
+            assert_ne!(alloc1, alloc2);
+        });
+    }
+
+    #[test]
+    fn bytes_interning() {
+        BuilderCtx::with_default(|ctx| {
+            let alloc1 = ctx.intern_bytes(&[1, 2, 3, 4]);
+            let alloc2 = ctx.intern_bytes(&[5, 6, 7, 8]);
+
+            assert_ne!(alloc1, alloc2);
+        });
+    }
+
+    #[test]
+    fn type_list_interning() {
+        BuilderCtx::with_default(|ctx| {
+            let i32_ty = ctx.i32();
+            let f64_ty = ctx.f64();
+
+            let list = ctx.type_list(&[i32_ty, f64_ty]);
+            assert_eq!(list.as_slice().len(), 2);
+        });
+    }
+
+    #[test]
+    fn layout_computation() {
+        BuilderCtx::with_default(|ctx| {
+            let i32_ty = ctx.i32();
+            let layout = ctx.layout_of(i32_ty);
+
+            assert_eq!(layout.layout.size.bytes(), 4);
+        });
+    }
+
+    #[test]
+    fn with_target_sets_backend() {
+        BuilderCtx::with_target(BackendKind::Llvm, EmitKind::LlvmIr, |ctx| {
+            assert!(matches!(ctx.backend_kind(), BackendKind::Llvm));
+            assert!(matches!(ctx.emit_kind(), EmitKind::LlvmIr));
+        });
+    }
+
+    #[test]
+    fn factory_methods_create_builders() {
+        use tidec_tir::body::*;
+        use tidec_tir::syntax::*;
+
+        BuilderCtx::with_default(|ctx| {
+            let metadata = TirBodyMetadata {
+                def_id: DefId(0),
+                name: "test_fn".to_string(),
+                kind: TirBodyKind::Item(TirItemKind::Function),
+                inlined: false,
+                linkage: Linkage::External,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+                call_conv: CallConv::C,
+                is_varargs: false,
+                is_declaration: false,
+            };
+
+            let mut fb = ctx.function_builder(metadata);
+            fb.declare_ret(ctx.i32(), false);
+            let entry = fb.create_block();
+            fb.set_terminator(entry, Terminator::Return);
+            let body = fb.build();
+
+            assert_eq!(body.metadata.name, "test_fn");
+
+            let mut unit = ctx.unit_builder("test_module");
+            unit.add_body(body);
+            let tir_unit = unit.build();
+
+            assert_eq!(tir_unit.metadata.unit_name, "test_module");
+            assert_eq!(tir_unit.bodies.len(), 1);
+        });
+    }
+}

--- a/compiler/tidec_builder/src/function_builder.rs
+++ b/compiler/tidec_builder/src/function_builder.rs
@@ -1,0 +1,613 @@
+//! Builder for constructing a [`TirBody`] (function / closure / coroutine).
+//!
+//! [`FunctionBuilder`] provides a high-level API that lets compiler front-ends
+//! incrementally build a TIR function body without having to manually manage
+//! local indices, basic-block indices, or the low-level data structures.
+//!
+//! # Workflow
+//!
+//! 1. Create a [`FunctionBuilder`] with [`FunctionBuilder::new`], supplying the
+//!    function metadata.
+//! 2. Declare the return type and parameter types with
+//!    [`declare_ret`](FunctionBuilder::declare_ret) and
+//!    [`declare_arg`](FunctionBuilder::declare_arg).
+//! 3. Declare additional locals with [`declare_local`](FunctionBuilder::declare_local).
+//! 4. Create basic blocks with [`create_block`](FunctionBuilder::create_block).
+//! 5. Fill each block using [`block_builder`](FunctionBuilder::block_builder) or
+//!    the convenience methods that operate directly on blocks.
+//! 6. Call [`build`](FunctionBuilder::build) to produce the final [`TirBody`].
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use tidec_builder::FunctionBuilder;
+//! use tidec_tir::body::*;
+//! use tidec_tir::syntax::*;
+//!
+//! let metadata = TirBodyMetadata { /* … */ };
+//! let mut fb = FunctionBuilder::new(metadata);
+//!
+//! // _0: i32 (return place)
+//! fb.declare_ret(i32_ty, false);
+//! // _1: i32 (first argument)
+//! fb.declare_arg(i32_ty, false);
+//!
+//! let entry = fb.create_block();
+//! {
+//!     let bb = fb.block_builder(entry);
+//!     bb.push_assign_operand(Place::from(RETURN_LOCAL), Operand::Use(Place::from(Local::new(1))));
+//! }
+//! fb.set_terminator(entry, Terminator::Return);
+//!
+//! let body = fb.build();
+//! ```
+
+use crate::basic_block_builder::BasicBlockBuilder;
+use tidec_tir::body::{TirBody, TirBodyMetadata};
+use tidec_tir::syntax::{
+    BasicBlock, BasicBlockData, Local, LocalData, Statement, Terminator, RETURN_LOCAL,
+};
+use tidec_tir::TirTy;
+use tidec_utils::idx::Idx;
+use tidec_utils::index_vec::IdxVec;
+
+/// Tracks in-progress basic blocks before they are finalized.
+///
+/// While the block is being built, it holds accumulated statements and an
+/// optional terminator. The block is not considered complete until a terminator
+/// has been set.
+struct InProgressBlock<'ctx> {
+    statements: Vec<Statement<'ctx>>,
+    terminator: Option<Terminator<'ctx>>,
+}
+
+impl<'ctx> InProgressBlock<'ctx> {
+    fn new() -> Self {
+        Self {
+            statements: Vec::new(),
+            terminator: None,
+        }
+    }
+}
+
+/// Builder for constructing a [`TirBody`].
+///
+/// See the [module-level documentation](self) for usage details.
+pub struct FunctionBuilder<'ctx> {
+    metadata: TirBodyMetadata,
+
+    /// Locals that form the return value + arguments.
+    /// `ret_and_args[0]` is always the return place.
+    ret_and_args: IdxVec<Local, LocalData<'ctx>>,
+
+    /// Additional (non-argument) locals.
+    locals: IdxVec<Local, LocalData<'ctx>>,
+
+    /// The total number of locals allocated so far (args + non-arg locals).
+    /// Used to hand out monotonically-increasing [`Local`] indices.
+    next_local_idx: usize,
+
+    /// In-progress basic blocks, indexed by [`BasicBlock`].
+    blocks: IdxVec<BasicBlock, InProgressBlock<'ctx>>,
+}
+
+impl<'ctx> FunctionBuilder<'ctx> {
+    /// Create a new function builder with the given metadata.
+    ///
+    /// No locals or basic blocks are created automatically – the caller must
+    /// at least call [`declare_ret`](Self::declare_ret) to set the return
+    /// place.
+    pub fn new(metadata: TirBodyMetadata) -> Self {
+        Self {
+            metadata,
+            ret_and_args: IdxVec::new(),
+            locals: IdxVec::new(),
+            next_local_idx: 0,
+            blocks: IdxVec::new(),
+        }
+    }
+
+    // ───────────────────── Local declarations ────────────────────
+
+    /// Declare the **return local** (`_0`).
+    ///
+    /// This must be the very first local declared; it will always receive
+    /// index `RETURN_LOCAL` (`Local(0)`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if any local has already been declared (i.e. `declare_ret` was
+    /// already called or an argument was declared first).
+    pub fn declare_ret(&mut self, ty: TirTy<'ctx>, mutable: bool) -> Local {
+        assert_eq!(
+            self.next_local_idx, 0,
+            "declare_ret must be the first local declaration"
+        );
+        let local = Local::new(self.next_local_idx);
+        debug_assert_eq!(local, RETURN_LOCAL);
+        self.ret_and_args.push(LocalData { ty, mutable });
+        self.next_local_idx += 1;
+        local
+    }
+
+    /// Declare a function **argument**.
+    ///
+    /// Arguments are stored immediately after the return local and must be
+    /// declared *after* [`declare_ret`](Self::declare_ret) and *before* any
+    /// call to [`declare_local`](Self::declare_local).
+    ///
+    /// Returns the [`Local`] index assigned to this argument.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the return local has not been declared yet.
+    pub fn declare_arg(&mut self, ty: TirTy<'ctx>, mutable: bool) -> Local {
+        assert!(
+            !self.ret_and_args.is_empty(),
+            "declare_ret must be called before declare_arg"
+        );
+        let local = Local::new(self.next_local_idx);
+        self.ret_and_args.push(LocalData { ty, mutable });
+        self.next_local_idx += 1;
+        local
+    }
+
+    /// Declare an additional (non-argument) **local variable**.
+    ///
+    /// Returns the [`Local`] index assigned to this local.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the return local has not been declared yet.
+    pub fn declare_local(&mut self, ty: TirTy<'ctx>, mutable: bool) -> Local {
+        assert!(
+            !self.ret_and_args.is_empty(),
+            "declare_ret must be called before declare_local"
+        );
+        let local = Local::new(self.next_local_idx);
+        self.locals.push(LocalData { ty, mutable });
+        self.next_local_idx += 1;
+        local
+    }
+
+    // ──────────────────── Basic-block management ─────────────────
+
+    /// Create a new, empty basic block and return its [`BasicBlock`] index.
+    ///
+    /// The first block created will be the entry block (`BasicBlock(0)`).
+    pub fn create_block(&mut self) -> BasicBlock {
+        let bb = BasicBlock::new(self.blocks.len());
+        self.blocks.push(InProgressBlock::new());
+        bb
+    }
+
+    /// Return a [`BasicBlockBuilder`] pre-populated with the statements that
+    /// have been pushed into `block` so far.
+    ///
+    /// **Important:** The builder is independent of the [`FunctionBuilder`]'s
+    /// internal storage. To persist the statements you build, call
+    /// [`apply_block_builder`](Self::apply_block_builder).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `block` has not been created yet.
+    pub fn block_builder(&self, block: BasicBlock) -> BasicBlockBuilder<'ctx> {
+        let _ = &self.blocks[block]; // bounds-check
+        BasicBlockBuilder::new()
+    }
+
+    /// Replace the contents of `block` with the result of a
+    /// [`BasicBlockBuilder`].
+    ///
+    /// This overwrites any previously pushed statements **and** the
+    /// terminator.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `block` has not been created yet.
+    pub fn apply_block_builder(&mut self, block: BasicBlock, data: BasicBlockData<'ctx>) {
+        let ip = &mut self.blocks[block];
+        ip.statements = data.statements;
+        ip.terminator = Some(data.terminator);
+    }
+
+    // ──────────────── Statement-level convenience API ────────────
+
+    /// Push a [`Statement`] to the end of `block`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `block` has not been created yet.
+    pub fn push_statement(&mut self, block: BasicBlock, stmt: Statement<'ctx>) {
+        self.blocks[block].statements.push(stmt);
+    }
+
+    /// Push an `Assign` statement to `block`.
+    pub fn push_assign(
+        &mut self,
+        block: BasicBlock,
+        place: tidec_tir::syntax::Place<'ctx>,
+        rvalue: tidec_tir::syntax::RValue<'ctx>,
+    ) {
+        self.push_statement(block, Statement::Assign(Box::new((place, rvalue))));
+    }
+
+    // ──────────────────── Terminator management ──────────────────
+
+    /// Set the terminator for `block`, overwriting any previously set
+    /// terminator.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `block` has not been created yet.
+    pub fn set_terminator(&mut self, block: BasicBlock, terminator: Terminator<'ctx>) {
+        self.blocks[block].terminator = Some(terminator);
+    }
+
+    /// Returns `true` if the given block already has a terminator set.
+    pub fn has_terminator(&self, block: BasicBlock) -> bool {
+        self.blocks[block].terminator.is_some()
+    }
+
+    // ──────────────────────── Introspection ──────────────────────
+
+    /// Returns the total number of locals declared so far (return + args +
+    /// other locals).
+    pub fn num_locals(&self) -> usize {
+        self.next_local_idx
+    }
+
+    /// Returns the number of arguments (excluding the return local).
+    pub fn num_args(&self) -> usize {
+        // ret_and_args contains return + args, so subtract 1 for the return
+        // place (if it exists).
+        if self.ret_and_args.is_empty() {
+            0
+        } else {
+            self.ret_and_args.len() - 1
+        }
+    }
+
+    /// Returns the number of basic blocks created so far.
+    pub fn num_blocks(&self) -> usize {
+        self.blocks.len()
+    }
+
+    // ────────────────────── Finalization ─────────────────────────
+
+    /// Consume the builder and produce the finished [`TirBody`].
+    ///
+    /// # Panics
+    ///
+    /// * Panics if the return local has not been declared.
+    /// * Panics if any basic block is missing its terminator.
+    pub fn build(self) -> TirBody<'ctx> {
+        assert!(
+            !self.ret_and_args.is_empty(),
+            "cannot build a TirBody without a return local (call declare_ret first)"
+        );
+
+        let mut basic_blocks: IdxVec<BasicBlock, BasicBlockData<'ctx>> = IdxVec::new();
+        for (bb_idx, ip) in self.blocks.iter_enumerated() {
+            let terminator = ip.terminator.clone().unwrap_or_else(|| {
+                panic!("basic block {:?} is missing a terminator", bb_idx);
+            });
+            basic_blocks.push(BasicBlockData {
+                statements: ip.statements.clone(),
+                terminator,
+            });
+        }
+
+        TirBody {
+            metadata: self.metadata,
+            ret_and_args: self.ret_and_args,
+            locals: self.locals,
+            basic_blocks,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidec_abi::target::{BackendKind, TirTarget};
+    use tidec_tir::body::*;
+    use tidec_tir::ctx::{EmitKind, InternCtx, TirArena, TirArgs, TirCtx};
+    use tidec_tir::syntax::*;
+    use tidec_tir::ty;
+
+    /// Helper to create a `TirCtx` for interning types in tests.
+    fn with_ctx<F, R>(f: F) -> R
+    where
+        F: for<'ctx> FnOnce(TirCtx<'ctx>) -> R,
+    {
+        let target = TirTarget::new(BackendKind::Llvm);
+        let args = TirArgs {
+            emit_kind: EmitKind::Object,
+        };
+        let arena = TirArena::default();
+        let intern_ctx = InternCtx::new(&arena);
+        let tir_ctx = TirCtx::new(&target, &args, &intern_ctx);
+        f(tir_ctx)
+    }
+
+    fn make_metadata(name: &str) -> TirBodyMetadata {
+        TirBodyMetadata {
+            def_id: DefId(0),
+            name: name.to_string(),
+            kind: TirBodyKind::Item(TirItemKind::Function),
+            inlined: false,
+            linkage: Linkage::External,
+            visibility: Visibility::Default,
+            unnamed_address: UnnamedAddress::None,
+            call_conv: CallConv::C,
+            is_varargs: false,
+            is_declaration: false,
+        }
+    }
+
+    #[test]
+    fn minimal_function_with_return() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut fb = FunctionBuilder::new(make_metadata("minimal"));
+            let ret = fb.declare_ret(i32_ty, false);
+            assert_eq!(ret, RETURN_LOCAL);
+
+            let entry = fb.create_block();
+            fb.set_terminator(entry, Terminator::Return);
+
+            let body = fb.build();
+            assert_eq!(body.ret_and_args.len(), 1); // only return local
+            assert!(body.locals.is_empty());
+            assert_eq!(body.basic_blocks.len(), 1);
+            assert!(matches!(
+                body.basic_blocks[BasicBlock::new(0)].terminator,
+                Terminator::Return
+            ));
+        });
+    }
+
+    #[test]
+    fn function_with_args_and_locals() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let f64_ty = ctx.intern_ty(ty::TirTy::F64);
+
+            let mut fb = FunctionBuilder::new(make_metadata("with_args"));
+            fb.declare_ret(i32_ty, false);
+            let arg1 = fb.declare_arg(i32_ty, false);
+            let arg2 = fb.declare_arg(f64_ty, false);
+            let tmp = fb.declare_local(i32_ty, true);
+
+            assert_eq!(arg1, Local::new(1));
+            assert_eq!(arg2, Local::new(2));
+            assert_eq!(tmp, Local::new(3));
+
+            assert_eq!(fb.num_args(), 2);
+            assert_eq!(fb.num_locals(), 4);
+
+            let entry = fb.create_block();
+            fb.set_terminator(entry, Terminator::Return);
+
+            let body = fb.build();
+            assert_eq!(body.ret_and_args.len(), 3); // ret + 2 args
+            assert_eq!(body.locals.len(), 1); // 1 additional local
+        });
+    }
+
+    #[test]
+    fn push_statements_directly() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut fb = FunctionBuilder::new(make_metadata("push_stmts"));
+            fb.declare_ret(i32_ty, false);
+            let arg = fb.declare_arg(i32_ty, false);
+
+            let entry = fb.create_block();
+            fb.push_assign(
+                entry,
+                Place::from(RETURN_LOCAL),
+                RValue::Operand(Operand::Use(Place::from(arg))),
+            );
+            fb.set_terminator(entry, Terminator::Return);
+
+            let body = fb.build();
+            assert_eq!(body.basic_blocks[BasicBlock::new(0)].statements.len(), 1);
+        });
+    }
+
+    #[test]
+    fn multiple_blocks_with_goto() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut fb = FunctionBuilder::new(make_metadata("multi_block"));
+            fb.declare_ret(i32_ty, false);
+
+            let entry = fb.create_block();
+            let exit = fb.create_block();
+
+            fb.set_terminator(entry, Terminator::Goto { target: exit });
+            fb.set_terminator(exit, Terminator::Return);
+
+            assert_eq!(fb.num_blocks(), 2);
+            assert!(fb.has_terminator(entry));
+            assert!(fb.has_terminator(exit));
+
+            let body = fb.build();
+            assert_eq!(body.basic_blocks.len(), 2);
+            assert!(matches!(
+                body.basic_blocks[BasicBlock::new(0)].terminator,
+                Terminator::Goto { target } if target == BasicBlock::new(1)
+            ));
+        });
+    }
+
+    #[test]
+    fn apply_block_builder_replaces_content() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut fb = FunctionBuilder::new(make_metadata("apply_bb"));
+            fb.declare_ret(i32_ty, false);
+            fb.declare_arg(i32_ty, false);
+
+            let entry = fb.create_block();
+
+            // Build the block externally.
+            let mut bb = BasicBlockBuilder::new();
+            bb.push_assign_operand(
+                Place::from(RETURN_LOCAL),
+                Operand::Use(Place::from(Local::new(1))),
+            );
+            let data = bb.build(Terminator::Return);
+
+            fb.apply_block_builder(entry, data);
+            let body = fb.build();
+
+            assert_eq!(body.basic_blocks[BasicBlock::new(0)].statements.len(), 1);
+            assert!(matches!(
+                body.basic_blocks[BasicBlock::new(0)].terminator,
+                Terminator::Return
+            ));
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "declare_ret must be the first local declaration")]
+    fn declare_ret_twice_panics() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let mut fb = FunctionBuilder::new(make_metadata("bad"));
+            fb.declare_ret(i32_ty, false);
+            fb.declare_ret(i32_ty, false); // should panic
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "declare_ret must be called before declare_arg")]
+    fn declare_arg_before_ret_panics() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let mut fb = FunctionBuilder::new(make_metadata("bad"));
+            fb.declare_arg(i32_ty, false); // should panic
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot build a TirBody without a return local")]
+    fn build_without_ret_panics() {
+        let fb = FunctionBuilder::new(make_metadata("no_ret"));
+        fb.build();
+    }
+
+    #[test]
+    #[should_panic(expected = "missing a terminator")]
+    fn build_with_missing_terminator_panics() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let mut fb = FunctionBuilder::new(make_metadata("no_term"));
+            fb.declare_ret(i32_ty, false);
+            fb.create_block(); // no terminator set
+            fb.build();
+        });
+    }
+
+    #[test]
+    fn set_terminator_overwrites() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut fb = FunctionBuilder::new(make_metadata("overwrite"));
+            fb.declare_ret(i32_ty, false);
+
+            let entry = fb.create_block();
+            fb.set_terminator(entry, Terminator::Unreachable);
+            fb.set_terminator(entry, Terminator::Return);
+
+            let body = fb.build();
+            assert!(matches!(
+                body.basic_blocks[BasicBlock::new(0)].terminator,
+                Terminator::Return
+            ));
+        });
+    }
+
+    #[test]
+    fn num_args_with_no_ret_returns_zero() {
+        let fb = FunctionBuilder::<'_>::new(make_metadata("empty"));
+        assert_eq!(fb.num_args(), 0);
+    }
+
+    #[test]
+    fn block_builder_returns_fresh_builder() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut fb = FunctionBuilder::new(make_metadata("fresh_bb"));
+            fb.declare_ret(i32_ty, false);
+            let entry = fb.create_block();
+
+            let bb = fb.block_builder(entry);
+            assert!(bb.is_empty());
+        });
+    }
+
+    #[test]
+    fn function_with_call_terminator() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let unit_ty = ctx.intern_ty(ty::TirTy::Unit);
+
+            let mut fb = FunctionBuilder::new(make_metadata("caller"));
+            fb.declare_ret(unit_ty, false);
+            let arg = fb.declare_arg(i32_ty, false);
+            let dest = fb.declare_local(i32_ty, true);
+
+            let entry = fb.create_block();
+            let cont = fb.create_block();
+
+            fb.set_terminator(
+                entry,
+                Terminator::Call {
+                    func: Operand::Use(Place::from(arg)),
+                    args: vec![Operand::Use(Place::from(arg))],
+                    destination: Place::from(dest),
+                    target: cont,
+                },
+            );
+            fb.set_terminator(cont, Terminator::Return);
+
+            let body = fb.build();
+            assert_eq!(body.basic_blocks.len(), 2);
+            assert!(matches!(
+                body.basic_blocks[BasicBlock::new(0)].terminator,
+                Terminator::Call { .. }
+            ));
+        });
+    }
+
+    #[test]
+    fn function_metadata_preserved() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut fb = FunctionBuilder::new(make_metadata("my_fn"));
+            fb.declare_ret(i32_ty, false);
+            let entry = fb.create_block();
+            fb.set_terminator(entry, Terminator::Return);
+
+            let body = fb.build();
+            assert_eq!(body.metadata.name, "my_fn");
+            assert!(matches!(
+                body.metadata.kind,
+                TirBodyKind::Item(TirItemKind::Function)
+            ));
+            assert!(!body.metadata.is_varargs);
+            assert!(!body.metadata.is_declaration);
+        });
+    }
+}

--- a/compiler/tidec_builder/src/lib.rs
+++ b/compiler/tidec_builder/src/lib.rs
@@ -9,6 +9,7 @@
 //!
 //! | Builder | Purpose |
 //! |---|---|
+//! | [`BuilderCtx`] | Manages arena and interning, provides ergonomic type creation. |
 //! | [`UnitBuilder`] | Construct a [`TirUnit`] (module) with globals and function bodies. |
 //! | [`FunctionBuilder`] | Construct a [`TirBody`] (function / closure / coroutine). |
 //! | [`BasicBlockBuilder`] | Append statements and set the terminator of a single basic block. |
@@ -16,23 +17,32 @@
 //! ## Example (pseudo-code)
 //!
 //! ```rust,ignore
-//! use tidec_builder::{UnitBuilder, FunctionBuilder};
+//! use tidec_builder::BuilderCtx;
 //!
-//! let mut unit = UnitBuilder::new("my_module");
+//! BuilderCtx::with_default(|ctx| {
+//!     // Create types without manual interning
+//!     let i32_ty = ctx.i32();
+//!     let f64_ty = ctx.f64();
 //!
-//! let mut func = FunctionBuilder::new("main", &tir_ctx);
-//! let entry = func.create_block();
-//! // ... emit statements and terminators via the function builder ...
-//! func.set_terminator(entry, Terminator::Return);
+//!     // Create a function
+//!     let mut func = ctx.function_builder(metadata);
+//!     func.declare_ret(i32_ty, false);
+//!     let entry = func.create_block();
+//!     func.set_terminator(entry, Terminator::Return);
 //!
-//! unit.add_body(func.build());
-//! let tir_unit = unit.build();
+//!     // Create a module
+//!     let mut unit = ctx.unit_builder("my_module");
+//!     unit.add_body(func.build());
+//!     let tir_unit = unit.build();
+//! });
 //! ```
 
 pub mod basic_block_builder;
+pub mod builder_ctx;
 pub mod function_builder;
 pub mod unit_builder;
 
 pub use basic_block_builder::BasicBlockBuilder;
+pub use builder_ctx::BuilderCtx;
 pub use function_builder::FunctionBuilder;
 pub use unit_builder::UnitBuilder;

--- a/compiler/tidec_builder/src/lib.rs
+++ b/compiler/tidec_builder/src/lib.rs
@@ -1,0 +1,38 @@
+//! # tidec_builder – Programmatic construction of Tide IR
+//!
+//! `tidec_builder` provides a high-level, ergonomic API for compiler front-ends
+//! that want to target the Tide Intermediate Representation (TIR). Instead of
+//! manually assembling [`TirUnit`], [`TirBody`], [`BasicBlockData`] and all of
+//! their substructures, users can rely on the builder types exposed here.
+//!
+//! ## Quick overview
+//!
+//! | Builder | Purpose |
+//! |---|---|
+//! | [`UnitBuilder`] | Construct a [`TirUnit`] (module) with globals and function bodies. |
+//! | [`FunctionBuilder`] | Construct a [`TirBody`] (function / closure / coroutine). |
+//! | [`BasicBlockBuilder`] | Append statements and set the terminator of a single basic block. |
+//!
+//! ## Example (pseudo-code)
+//!
+//! ```rust,ignore
+//! use tidec_builder::{UnitBuilder, FunctionBuilder};
+//!
+//! let mut unit = UnitBuilder::new("my_module");
+//!
+//! let mut func = FunctionBuilder::new("main", &tir_ctx);
+//! let entry = func.create_block();
+//! // ... emit statements and terminators via the function builder ...
+//! func.set_terminator(entry, Terminator::Return);
+//!
+//! unit.add_body(func.build());
+//! let tir_unit = unit.build();
+//! ```
+
+pub mod basic_block_builder;
+pub mod function_builder;
+pub mod unit_builder;
+
+pub use basic_block_builder::BasicBlockBuilder;
+pub use function_builder::FunctionBuilder;
+pub use unit_builder::UnitBuilder;

--- a/compiler/tidec_builder/src/unit_builder.rs
+++ b/compiler/tidec_builder/src/unit_builder.rs
@@ -1,0 +1,494 @@
+//! Builder for constructing a [`TirUnit`] (module).
+//!
+//! A [`UnitBuilder`] provides an ergonomic API for incrementally assembling a
+//! complete TIR module. It collects global variables and function bodies and
+//! produces a [`TirUnit`] when [`build`](UnitBuilder::build) is called.
+//!
+//! # Workflow
+//!
+//! 1. Create a [`UnitBuilder`] with [`UnitBuilder::new`], supplying the module
+//!    name.
+//! 2. Add global variables with [`add_global`](UnitBuilder::add_global).
+//! 3. Add function bodies with [`add_body`](UnitBuilder::add_body).
+//! 4. Call [`build`](UnitBuilder::build) to produce the final [`TirUnit`].
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use tidec_builder::UnitBuilder;
+//! use tidec_tir::body::*;
+//!
+//! let mut unit = UnitBuilder::new("my_module");
+//! let gid = unit.add_global(my_global);
+//! unit.add_body(my_function_body);
+//! let tir_unit = unit.build();
+//! ```
+
+use tidec_tir::body::{Body, GlobalId, TirBody, TirGlobal, TirUnit, TirUnitMetadata};
+use tidec_utils::idx::Idx;
+use tidec_utils::index_vec::IdxVec;
+
+/// Builder for constructing a [`TirUnit`].
+///
+/// See the [module-level documentation](self) for usage details.
+pub struct UnitBuilder<'ctx> {
+    /// The name of the unit (module).
+    unit_name: String,
+
+    /// Accumulated global variables.
+    globals: IdxVec<GlobalId, TirGlobal<'ctx>>,
+
+    /// Accumulated function bodies.
+    bodies: IdxVec<Body, TirBody<'ctx>>,
+}
+
+impl<'ctx> UnitBuilder<'ctx> {
+    /// Create a new unit builder for a module with the given name.
+    pub fn new(unit_name: impl Into<String>) -> Self {
+        Self {
+            unit_name: unit_name.into(),
+            globals: IdxVec::new(),
+            bodies: IdxVec::new(),
+        }
+    }
+
+    // ────────────────────── Global variables ─────────────────────
+
+    /// Add a global variable to the module.
+    ///
+    /// Returns the [`GlobalId`] assigned to the global, which can be used
+    /// to reference it from function bodies (e.g. via
+    /// [`TirCtx::intern_static`]).
+    pub fn add_global(&mut self, global: TirGlobal<'ctx>) -> GlobalId {
+        self.globals.push(global)
+    }
+
+    /// Returns the number of globals added so far.
+    pub fn num_globals(&self) -> usize {
+        self.globals.len()
+    }
+
+    /// Returns `true` if no globals have been added.
+    pub fn has_globals(&self) -> bool {
+        !self.globals.is_empty()
+    }
+
+    /// Returns a shared reference to a previously added global.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` is out of bounds.
+    pub fn get_global(&self, id: GlobalId) -> &TirGlobal<'ctx> {
+        &self.globals.raw[id.idx()]
+    }
+
+    /// Returns a mutable reference to a previously added global, allowing
+    /// in-place modification before the unit is finalized.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` is out of bounds.
+    pub fn get_global_mut(&mut self, id: GlobalId) -> &mut TirGlobal<'ctx> {
+        &mut self.globals.raw[id.idx()]
+    }
+
+    // ──────────────────── Function bodies ────────────────────────
+
+    /// Add a function body to the module.
+    ///
+    /// Returns the [`Body`] index assigned to this body within the unit.
+    pub fn add_body(&mut self, body: TirBody<'ctx>) -> Body {
+        self.bodies.push(body)
+    }
+
+    /// Returns the number of function bodies added so far.
+    pub fn num_bodies(&self) -> usize {
+        self.bodies.len()
+    }
+
+    /// Returns `true` if no bodies have been added.
+    pub fn has_bodies(&self) -> bool {
+        !self.bodies.is_empty()
+    }
+
+    /// Returns a shared reference to a previously added body.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` is out of bounds.
+    pub fn get_body(&self, id: &Body) -> &TirBody<'ctx> {
+        &self.bodies.raw[id.idx()]
+    }
+
+    /// Returns a mutable reference to a previously added body, allowing
+    /// in-place modification before the unit is finalized.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `id` is out of bounds.
+    pub fn get_body_mut(&mut self, id: &Body) -> &mut TirBody<'ctx> {
+        &mut self.bodies.raw[id.idx()]
+    }
+
+    // ──────────────────── Introspection ──────────────────────────
+
+    /// Returns the module name.
+    pub fn unit_name(&self) -> &str {
+        &self.unit_name
+    }
+
+    // ──────────────────── Finalization ───────────────────────────
+
+    /// Consume the builder and produce the finished [`TirUnit`].
+    pub fn build(self) -> TirUnit<'ctx> {
+        TirUnit {
+            metadata: TirUnitMetadata {
+                unit_name: self.unit_name,
+            },
+            globals: self.globals,
+            bodies: self.bodies,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tidec_abi::target::{BackendKind, TirTarget};
+    use tidec_tir::body::*;
+    use tidec_tir::ctx::{EmitKind, InternCtx, TirArena, TirArgs, TirCtx};
+    use tidec_tir::syntax::*;
+    use tidec_tir::ty;
+    use tidec_utils::idx::Idx;
+
+    /// Helper to create a `TirCtx` for interning types in tests.
+    fn with_ctx<F, R>(f: F) -> R
+    where
+        F: for<'ctx> FnOnce(TirCtx<'ctx>) -> R,
+    {
+        let target = TirTarget::new(BackendKind::Llvm);
+        let args = TirArgs {
+            emit_kind: EmitKind::Object,
+        };
+        let arena = TirArena::default();
+        let intern_ctx = InternCtx::new(&arena);
+        let tir_ctx = TirCtx::new(&target, &args, &intern_ctx);
+        f(tir_ctx)
+    }
+
+    fn make_metadata(name: &str) -> TirBodyMetadata {
+        TirBodyMetadata {
+            def_id: DefId(0),
+            name: name.to_string(),
+            kind: TirBodyKind::Item(TirItemKind::Function),
+            inlined: false,
+            linkage: Linkage::External,
+            visibility: Visibility::Default,
+            unnamed_address: UnnamedAddress::None,
+            call_conv: CallConv::C,
+            is_varargs: false,
+            is_declaration: false,
+        }
+    }
+
+    fn make_simple_body<'ctx>(name: &str, ret_ty: tidec_tir::TirTy<'ctx>) -> TirBody<'ctx> {
+        use crate::FunctionBuilder;
+
+        let mut fb = FunctionBuilder::new(make_metadata(name));
+        fb.declare_ret(ret_ty, false);
+        let entry = fb.create_block();
+        fb.set_terminator(entry, Terminator::Return);
+        fb.build()
+    }
+
+    #[test]
+    fn empty_unit() {
+        let unit = UnitBuilder::new("empty_mod").build();
+        assert_eq!(unit.metadata.unit_name, "empty_mod");
+        assert!(unit.globals.is_empty());
+        assert!(unit.bodies.is_empty());
+    }
+
+    #[test]
+    fn unit_name_preserved() {
+        let ub = UnitBuilder::<'_>::new("my_module");
+        assert_eq!(ub.unit_name(), "my_module");
+        let unit = ub.build();
+        assert_eq!(unit.metadata.unit_name, "my_module");
+    }
+
+    #[test]
+    fn add_single_body() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut ub = UnitBuilder::new("one_fn");
+            let body = make_simple_body("my_fn", i32_ty);
+            let body_id = ub.add_body(body);
+            assert!(body_id.idx() == 0);
+            assert_eq!(ub.num_bodies(), 1);
+            assert!(ub.has_bodies());
+
+            let unit = ub.build();
+            assert_eq!(unit.bodies.len(), 1);
+            assert_eq!(unit.bodies.raw[0].metadata.name, "my_fn");
+        });
+    }
+
+    #[test]
+    fn add_multiple_bodies() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let unit_ty = ctx.intern_ty(ty::TirTy::Unit);
+
+            let mut ub = UnitBuilder::new("multi_fn");
+            let b0 = ub.add_body(make_simple_body("fn_a", i32_ty));
+            let b1 = ub.add_body(make_simple_body("fn_b", unit_ty));
+            let b2 = ub.add_body(make_simple_body("fn_c", i32_ty));
+
+            assert!(b0.idx() == 0);
+            assert!(b1.idx() == 1);
+            assert!(b2.idx() == 2);
+            assert_eq!(ub.num_bodies(), 3);
+
+            let unit = ub.build();
+            assert_eq!(unit.bodies.len(), 3);
+            assert_eq!(unit.bodies.raw[0].metadata.name, "fn_a");
+            assert_eq!(unit.bodies.raw[1].metadata.name, "fn_b");
+            assert_eq!(unit.bodies.raw[2].metadata.name, "fn_c");
+        });
+    }
+
+    #[test]
+    fn add_global_scalar() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut ub = UnitBuilder::new("with_global");
+
+            let scalar = ConstScalar::Value(RawScalarValue {
+                data: 42,
+                size: std::num::NonZero::new(4).unwrap(),
+            });
+            let global = TirGlobal {
+                name: "counter".to_string(),
+                ty: i32_ty,
+                initializer: Some(ConstValue::Scalar(scalar)),
+                mutable: true,
+                linkage: Linkage::External,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+            };
+
+            let gid = ub.add_global(global);
+            assert_eq!(gid, GlobalId::new(0));
+            assert_eq!(ub.num_globals(), 1);
+            assert!(ub.has_globals());
+
+            let unit = ub.build();
+            assert_eq!(unit.globals.len(), 1);
+            assert_eq!(unit.globals[GlobalId::new(0)].name, "counter");
+            assert!(unit.globals[GlobalId::new(0)].mutable);
+        });
+    }
+
+    #[test]
+    fn add_global_declaration_no_initializer() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut ub = UnitBuilder::new("extern_mod");
+            let global = TirGlobal {
+                name: "ext_var".to_string(),
+                ty: i32_ty,
+                initializer: None,
+                mutable: false,
+                linkage: Linkage::External,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+            };
+
+            let gid = ub.add_global(global);
+            let unit = ub.build();
+            assert!(unit.globals[gid].initializer.is_none());
+        });
+    }
+
+    #[test]
+    fn get_global_by_id() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut ub = UnitBuilder::new("get_global");
+            let global = TirGlobal {
+                name: "my_global".to_string(),
+                ty: i32_ty,
+                initializer: None,
+                mutable: false,
+                linkage: Linkage::Internal,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+            };
+
+            let gid = ub.add_global(global);
+            assert_eq!(ub.get_global(gid).name, "my_global");
+        });
+    }
+
+    #[test]
+    fn get_global_mut_by_id() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut ub = UnitBuilder::new("mutate_global");
+            let global = TirGlobal {
+                name: "orig".to_string(),
+                ty: i32_ty,
+                initializer: None,
+                mutable: false,
+                linkage: Linkage::External,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+            };
+
+            let gid = ub.add_global(global);
+            ub.get_global_mut(gid).name = "renamed".to_string();
+            assert_eq!(ub.get_global(gid).name, "renamed");
+        });
+    }
+
+    #[test]
+    fn get_body_by_id() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut ub = UnitBuilder::new("get_body");
+            let body_id = ub.add_body(make_simple_body("fn_x", i32_ty));
+            assert_eq!(ub.get_body(&body_id).metadata.name, "fn_x");
+        });
+    }
+
+    #[test]
+    fn get_body_mut_by_id() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut ub = UnitBuilder::new("mutate_body");
+            let body_id = ub.add_body(make_simple_body("fn_orig", i32_ty));
+            ub.get_body_mut(&body_id).metadata.name = "fn_renamed".to_string();
+            assert_eq!(ub.get_body(&body_id).metadata.name, "fn_renamed");
+        });
+    }
+
+    #[test]
+    fn unit_with_globals_and_bodies() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let unit_ty = ctx.intern_ty(ty::TirTy::Unit);
+
+            let mut ub = UnitBuilder::new("full_module");
+
+            // Add globals
+            let g0 = ub.add_global(TirGlobal {
+                name: "g0".to_string(),
+                ty: i32_ty,
+                initializer: Some(ConstValue::ZST),
+                mutable: false,
+                linkage: Linkage::Internal,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::Local,
+            });
+            let g1 = ub.add_global(TirGlobal {
+                name: "g1".to_string(),
+                ty: unit_ty,
+                initializer: None,
+                mutable: true,
+                linkage: Linkage::External,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+            });
+
+            // Add bodies
+            let b0 = ub.add_body(make_simple_body("main", unit_ty));
+            let b1 = ub.add_body(make_simple_body("helper", i32_ty));
+
+            assert_eq!(ub.num_globals(), 2);
+            assert_eq!(ub.num_bodies(), 2);
+
+            let unit = ub.build();
+            assert_eq!(unit.metadata.unit_name, "full_module");
+            assert_eq!(unit.globals.len(), 2);
+            assert_eq!(unit.bodies.len(), 2);
+            assert_eq!(unit.globals[g0].name, "g0");
+            assert_eq!(unit.globals[g1].name, "g1");
+            assert_eq!(unit.bodies.raw[b0.idx()].metadata.name, "main");
+            assert_eq!(unit.bodies.raw[b1.idx()].metadata.name, "helper");
+        });
+    }
+
+    #[test]
+    fn has_globals_and_has_bodies_on_empty() {
+        let ub = UnitBuilder::<'_>::new("empty");
+        assert!(!ub.has_globals());
+        assert!(!ub.has_bodies());
+        assert_eq!(ub.num_globals(), 0);
+        assert_eq!(ub.num_bodies(), 0);
+    }
+
+    #[test]
+    fn unit_name_from_string() {
+        let name = String::from("dynamic_name");
+        let ub = UnitBuilder::<'_>::new(name);
+        assert_eq!(ub.unit_name(), "dynamic_name");
+    }
+
+    #[test]
+    fn multiple_globals_indices_are_sequential() {
+        with_ctx(|ctx| {
+            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+            let mut ub = UnitBuilder::new("sequential");
+            let make_global = |name: &str| TirGlobal {
+                name: name.to_string(),
+                ty: i32_ty,
+                initializer: None,
+                mutable: false,
+                linkage: Linkage::External,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+            };
+
+            let g0 = ub.add_global(make_global("a"));
+            let g1 = ub.add_global(make_global("b"));
+            let g2 = ub.add_global(make_global("c"));
+
+            assert_eq!(g0, GlobalId::new(0));
+            assert_eq!(g1, GlobalId::new(1));
+            assert_eq!(g2, GlobalId::new(2));
+        });
+    }
+
+    #[test]
+    fn global_with_null_ptr_initializer() {
+        with_ctx(|ctx| {
+            let ptr_ty = ctx.intern_ty(ty::TirTy::RawPtr(
+                ctx.intern_ty(ty::TirTy::I32),
+                ty::Mutability::Imm,
+            ));
+
+            let mut ub = UnitBuilder::new("null_ptr_mod");
+            let gid = ub.add_global(TirGlobal {
+                name: "null_g".to_string(),
+                ty: ptr_ty,
+                initializer: Some(ConstValue::NullPtr),
+                mutable: false,
+                linkage: Linkage::External,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+            });
+
+            let unit = ub.build();
+            assert_eq!(unit.globals[gid].initializer, Some(ConstValue::NullPtr));
+        });
+    }
+}

--- a/compiler/tidec_builder/src/unit_builder.rs
+++ b/compiler/tidec_builder/src/unit_builder.rs
@@ -154,6 +154,7 @@ impl<'ctx> UnitBuilder<'ctx> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::BuilderCtx;
     use tidec_abi::target::{BackendKind, TirTarget};
     use tidec_tir::body::*;
     use tidec_tir::ctx::{EmitKind, InternCtx, TirArena, TirArgs, TirCtx};
@@ -220,7 +221,8 @@ mod tests {
     #[test]
     fn add_single_body() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
 
             let mut ub = UnitBuilder::new("one_fn");
             let body = make_simple_body("my_fn", i32_ty);
@@ -238,8 +240,9 @@ mod tests {
     #[test]
     fn add_multiple_bodies() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
-            let unit_ty = ctx.intern_ty(ty::TirTy::Unit);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
+            let unit_ty = builder_ctx.unit();
 
             let mut ub = UnitBuilder::new("multi_fn");
             let b0 = ub.add_body(make_simple_body("fn_a", i32_ty));
@@ -262,7 +265,8 @@ mod tests {
     #[test]
     fn add_global_scalar() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
 
             let mut ub = UnitBuilder::new("with_global");
 
@@ -295,7 +299,8 @@ mod tests {
     #[test]
     fn add_global_declaration_no_initializer() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
 
             let mut ub = UnitBuilder::new("extern_mod");
             let global = TirGlobal {
@@ -317,7 +322,8 @@ mod tests {
     #[test]
     fn get_global_by_id() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
 
             let mut ub = UnitBuilder::new("get_global");
             let global = TirGlobal {
@@ -338,7 +344,8 @@ mod tests {
     #[test]
     fn get_global_mut_by_id() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
 
             let mut ub = UnitBuilder::new("mutate_global");
             let global = TirGlobal {
@@ -360,7 +367,8 @@ mod tests {
     #[test]
     fn get_body_by_id() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
 
             let mut ub = UnitBuilder::new("get_body");
             let body_id = ub.add_body(make_simple_body("fn_x", i32_ty));
@@ -371,7 +379,8 @@ mod tests {
     #[test]
     fn get_body_mut_by_id() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
 
             let mut ub = UnitBuilder::new("mutate_body");
             let body_id = ub.add_body(make_simple_body("fn_orig", i32_ty));
@@ -383,8 +392,9 @@ mod tests {
     #[test]
     fn unit_with_globals_and_bodies() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
-            let unit_ty = ctx.intern_ty(ty::TirTy::Unit);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
+            let unit_ty = builder_ctx.unit();
 
             let mut ub = UnitBuilder::new("full_module");
 
@@ -445,7 +455,8 @@ mod tests {
     #[test]
     fn multiple_globals_indices_are_sequential() {
         with_ctx(|ctx| {
-            let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
 
             let mut ub = UnitBuilder::new("sequential");
             let make_global = |name: &str| TirGlobal {
@@ -471,10 +482,9 @@ mod tests {
     #[test]
     fn global_with_null_ptr_initializer() {
         with_ctx(|ctx| {
-            let ptr_ty = ctx.intern_ty(ty::TirTy::RawPtr(
-                ctx.intern_ty(ty::TirTy::I32),
-                ty::Mutability::Imm,
-            ));
+            let builder_ctx = BuilderCtx::new(ctx);
+            let i32_ty = builder_ctx.i32();
+            let ptr_ty = builder_ctx.ptr_imm(i32_ty);
 
             let mut ub = UnitBuilder::new("null_ptr_mod");
             let gid = ub.add_global(TirGlobal {

--- a/compiler/tidec_builder/tests/integration_tests.rs
+++ b/compiler/tidec_builder/tests/integration_tests.rs
@@ -2,31 +2,16 @@
 //!
 //! Each test constructs a complete TIR module end-to-end using the builder API
 //! and then asserts on the resulting structure.
+//!
+//! These tests use the new `BuilderCtx` API which handles interning automatically.
 
 use std::num::NonZero;
 
-use tidec_abi::target::{BackendKind, TirTarget};
-use tidec_builder::{BasicBlockBuilder, FunctionBuilder, UnitBuilder};
+use tidec_builder::{BasicBlockBuilder, BuilderCtx};
 use tidec_tir::body::*;
-use tidec_tir::ctx::{EmitKind, InternCtx, TirArena, TirArgs, TirCtx};
 use tidec_tir::syntax::*;
-use tidec_tir::ty;
+use tidec_tir::ty::Mutability;
 use tidec_utils::idx::Idx;
-
-/// Helper to run a closure with a fresh `TirCtx`.
-fn with_ctx<F, R>(f: F) -> R
-where
-    F: for<'ctx> FnOnce(TirCtx<'ctx>) -> R,
-{
-    let target = TirTarget::new(BackendKind::Llvm);
-    let args = TirArgs {
-        emit_kind: EmitKind::Object,
-    };
-    let arena = TirArena::default();
-    let intern_ctx = InternCtx::new(&arena);
-    let tir_ctx = TirCtx::new(&target, &args, &intern_ctx);
-    f(tir_ctx)
-}
 
 fn make_metadata(name: &str) -> TirBodyMetadata {
     TirBodyMetadata {
@@ -49,11 +34,11 @@ fn make_metadata(name: &str) -> TirBodyMetadata {
 
 #[test]
 fn build_add_function_module() {
-    with_ctx(|ctx| {
-        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
 
         // -- Build the function body: i32 add(i32 %a, i32 %b) { return %a + %b; }
-        let mut fb = FunctionBuilder::new(make_metadata("add"));
+        let mut fb = ctx.function_builder(make_metadata("add"));
 
         // _0: i32 (return place)
         let ret = fb.declare_ret(i32_ty, false);
@@ -97,7 +82,7 @@ fn build_add_function_module() {
         assert!(matches!(bb0.terminator, Terminator::Return));
 
         // -- Wrap the body in a module.
-        let mut unit = UnitBuilder::new("add_module");
+        let mut unit = ctx.unit_builder("add_module");
         let body_id = unit.add_body(body);
         assert!(body_id.idx() == 0);
         assert_eq!(unit.num_bodies(), 1);
@@ -121,9 +106,9 @@ fn build_add_function_module() {
 
 #[test]
 fn build_module_with_global_and_branch() {
-    with_ctx(|ctx| {
-        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
-        let bool_ty = ctx.intern_ty(ty::TirTy::Bool);
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
+        let bool_ty = ctx.bool();
 
         // -- Global: `counter = 0`
         let scalar_zero = ConstScalar::Value(RawScalarValue {
@@ -141,7 +126,7 @@ fn build_module_with_global_and_branch() {
         };
 
         // -- Function: maybe_increment
-        let mut fb = FunctionBuilder::new(make_metadata("maybe_increment"));
+        let mut fb = ctx.function_builder(make_metadata("maybe_increment"));
         let _ret = fb.declare_ret(i32_ty, false);
         let cond = fb.declare_arg(bool_ty, false);
         let counter_local = fb.declare_local(i32_ty, false); // _3, holds loaded counter
@@ -221,7 +206,7 @@ fn build_module_with_global_and_branch() {
         assert!(matches!(merge_data.terminator, Terminator::Return));
 
         // -- Assemble the module.
-        let mut unit = UnitBuilder::new("branch_module");
+        let mut unit = ctx.unit_builder("branch_module");
         let gid = unit.add_global(global);
         let bid = unit.add_body(body);
 
@@ -250,14 +235,14 @@ fn build_module_with_global_and_branch() {
 
 #[test]
 fn build_module_with_declaration_and_call() {
-    with_ctx(|ctx| {
-        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
 
         // -- External declaration: i32 ext_fn(i32)
         let mut ext_meta = make_metadata("ext_fn");
         ext_meta.is_declaration = true;
         ext_meta.def_id = DefId(0);
-        let mut ext_fb = FunctionBuilder::new(ext_meta);
+        let mut ext_fb = ctx.function_builder(ext_meta);
         ext_fb.declare_ret(i32_ty, false);
         ext_fb.declare_arg(i32_ty, false);
         // Declarations don't need blocks.
@@ -272,7 +257,7 @@ fn build_module_with_declaration_and_call() {
         // -- Caller function: i32 caller(i32 %x) { return ext_fn(%x); }
         let mut caller_meta = make_metadata("caller");
         caller_meta.def_id = DefId(1);
-        let mut caller_fb = FunctionBuilder::new(caller_meta);
+        let mut caller_fb = ctx.function_builder(caller_meta);
 
         let _ret = caller_fb.declare_ret(i32_ty, false);
         let x = caller_fb.declare_arg(i32_ty, false);
@@ -310,7 +295,7 @@ fn build_module_with_declaration_and_call() {
         ));
 
         // -- Assemble the module.
-        let mut unit = UnitBuilder::new("call_module");
+        let mut unit = ctx.unit_builder("call_module");
         unit.add_body(ext_body);
         unit.add_body(caller_body);
 
@@ -337,17 +322,14 @@ fn build_module_with_declaration_and_call() {
 
 #[test]
 fn build_module_with_struct_aggregate() {
-    with_ctx(|ctx| {
-        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
-        let f64_ty = ctx.intern_ty(ty::TirTy::F64);
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
+        let f64_ty = ctx.f64();
 
-        let fields = ctx.intern_type_list(&[i32_ty, f64_ty]);
-        let pair_ty = ctx.intern_ty(ty::TirTy::Struct {
-            fields,
-            packed: false,
-        });
+        // Create struct type with automatic interning
+        let pair_ty = ctx.struct_ty(&[i32_ty, f64_ty], false);
 
-        let mut fb = FunctionBuilder::new(make_metadata("make_pair"));
+        let mut fb = ctx.function_builder(make_metadata("make_pair"));
         fb.declare_ret(pair_ty, false);
         let a = fb.declare_arg(i32_ty, false);
         let b = fb.declare_arg(f64_ty, false);
@@ -375,7 +357,7 @@ fn build_module_with_struct_aggregate() {
         let body = fb.build();
         assert_eq!(body.basic_blocks[BasicBlock::new(0)].statements.len(), 2);
 
-        let mut unit = UnitBuilder::new("struct_module");
+        let mut unit = ctx.unit_builder("struct_module");
         unit.add_body(body);
         let tir_unit = unit.build();
 
@@ -395,11 +377,11 @@ fn build_module_with_struct_aggregate() {
 
 #[test]
 fn build_module_with_cast() {
-    with_ctx(|ctx| {
-        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
-        let f64_ty = ctx.intern_ty(ty::TirTy::F64);
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
+        let f64_ty = ctx.f64();
 
-        let mut fb = FunctionBuilder::new(make_metadata("int_to_float"));
+        let mut fb = ctx.function_builder(make_metadata("int_to_float"));
         fb.declare_ret(f64_ty, false);
         let x = fb.declare_arg(i32_ty, false);
 
@@ -421,7 +403,7 @@ fn build_module_with_cast() {
         assert_eq!(body.basic_blocks.len(), 1);
         assert_eq!(body.basic_blocks[BasicBlock::new(0)].statements.len(), 1);
 
-        let mut unit = UnitBuilder::new("cast_module");
+        let mut unit = ctx.unit_builder("cast_module");
         unit.add_body(body);
         let tir_unit = unit.build();
 
@@ -441,27 +423,24 @@ fn build_module_with_cast() {
 
 #[test]
 fn build_module_with_address_of() {
-    with_ctx(|ctx| {
-        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
-        let ptr_ty = ctx.intern_ty(ty::TirTy::RawPtr(i32_ty, ty::Mutability::Imm));
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
+        // Create pointer type with automatic interning
+        let ptr_ty = ctx.ptr_imm(i32_ty);
 
-        let mut fb = FunctionBuilder::new(make_metadata("take_addr"));
+        let mut fb = ctx.function_builder(make_metadata("take_addr"));
         fb.declare_ret(ptr_ty, false);
         let x = fb.declare_arg(i32_ty, false);
 
         let entry = fb.create_block();
 
         let mut bb = BasicBlockBuilder::new();
-        bb.push_assign_address_of(
-            Place::from(RETURN_LOCAL),
-            ty::Mutability::Imm,
-            Place::from(x),
-        );
+        bb.push_assign_address_of(Place::from(RETURN_LOCAL), Mutability::Imm, Place::from(x));
         fb.apply_block_builder(entry, bb.build(Terminator::Return));
 
         let body = fb.build();
 
-        let mut unit = UnitBuilder::new("addr_module");
+        let mut unit = ctx.unit_builder("addr_module");
         unit.add_body(body);
         let tir_unit = unit.build();
 
@@ -476,11 +455,11 @@ fn build_module_with_address_of() {
 
 #[test]
 fn build_large_module() {
-    with_ctx(|ctx| {
-        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
-        let unit_ty = ctx.intern_ty(ty::TirTy::Unit);
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
+        let unit_ty = ctx.unit();
 
-        let mut unit = UnitBuilder::new("large_module");
+        let mut unit = ctx.unit_builder("large_module");
 
         // Add 5 globals.
         for i in 0..5 {
@@ -502,7 +481,7 @@ fn build_large_module() {
         // Add 3 trivial functions.
         for i in 0..3 {
             let ret_ty = if i == 0 { unit_ty } else { i32_ty };
-            let mut fb = FunctionBuilder::new(make_metadata(&format!("fn_{}", i)));
+            let mut fb = ctx.function_builder(make_metadata(&format!("fn_{}", i)));
             fb.declare_ret(ret_ty, false);
             let entry = fb.create_block();
             fb.set_terminator(entry, Terminator::Return);
@@ -535,10 +514,10 @@ fn build_large_module() {
 
 #[test]
 fn chaining_basic_block_builder_in_function() {
-    with_ctx(|ctx| {
-        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
 
-        let mut fb = FunctionBuilder::new(make_metadata("neg_and_not"));
+        let mut fb = ctx.function_builder(make_metadata("neg_and_not"));
         fb.declare_ret(i32_ty, false);
         let x = fb.declare_arg(i32_ty, false);
         let neg_tmp = fb.declare_local(i32_ty, true);
@@ -565,10 +544,129 @@ fn chaining_basic_block_builder_in_function() {
         let body = fb.build();
         assert_eq!(body.basic_blocks[BasicBlock::new(0)].statements.len(), 2);
 
-        let unit = UnitBuilder::new("chain_mod");
+        let unit = ctx.unit_builder("chain_mod");
         // We intentionally leave the module with zero bodies, just to show the
         // builder allows it.
         let tir_unit = unit.build();
         assert!(tir_unit.bodies.is_empty());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: verify type interning works correctly through BuilderCtx.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn type_interning_through_builder_ctx() {
+    BuilderCtx::with_default(|ctx| {
+        // Same type created multiple times should be deduplicated
+        let i32_a = ctx.i32();
+        let i32_b = ctx.i32();
+        assert_eq!(i32_a, i32_b);
+
+        // Different types should be different
+        let f64_ty = ctx.f64();
+        assert_ne!(i32_a, f64_ty);
+
+        // Pointer types should be deduplicated
+        let ptr1 = ctx.ptr_imm(i32_a);
+        let ptr2 = ctx.ptr_imm(i32_b);
+        assert_eq!(ptr1, ptr2);
+
+        // Mutable vs immutable pointers should differ
+        let ptr_mut = ctx.ptr_mut(i32_a);
+        assert_ne!(ptr1, ptr_mut);
+
+        // Struct types should work correctly
+        let struct1 = ctx.struct_ty(&[i32_a, f64_ty], false);
+        let struct2 = ctx.struct_ty(&[i32_b, f64_ty], false);
+        // Note: struct types may not be deduplicated at the type list level,
+        // but the internal types should be the same
+        assert!(struct1.is_struct());
+        assert!(struct2.is_struct());
+
+        // Array types
+        let arr = ctx.array(i32_a, 10);
+        assert!(arr.is_array());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: verify allocation interning through BuilderCtx.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn allocation_interning_through_builder_ctx() {
+    BuilderCtx::with_default(|ctx| {
+        // Intern C strings
+        let str1 = ctx.intern_c_str("hello");
+        let str2 = ctx.intern_c_str("world");
+        assert_ne!(str1, str2);
+
+        // Intern bytes
+        let bytes1 = ctx.intern_bytes(&[1, 2, 3, 4]);
+        let bytes2 = ctx.intern_bytes(&[5, 6, 7, 8]);
+        assert_ne!(bytes1, bytes2);
+
+        // Intern functions
+        let fn1 = ctx.intern_fn(DefId(0));
+        let fn2 = ctx.intern_fn(DefId(1));
+        assert_ne!(fn1, fn2);
+
+        // Intern statics
+        let static1 = ctx.intern_static(GlobalId::new(0));
+        let static2 = ctx.intern_static(GlobalId::new(1));
+        assert_ne!(static1, static2);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: build a module with arrays.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_module_with_array_type() {
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
+        let arr_ty = ctx.array(i32_ty, 4);
+
+        // Global array initialized to zeros
+        let global = TirGlobal {
+            name: "arr".to_string(),
+            ty: arr_ty,
+            initializer: Some(ConstValue::ZST), // placeholder
+            mutable: true,
+            linkage: Linkage::External,
+            visibility: Visibility::Default,
+            unnamed_address: UnnamedAddress::None,
+        };
+
+        let mut unit = ctx.unit_builder("array_module");
+        unit.add_global(global);
+
+        let tir_unit = unit.build();
+        assert_eq!(tir_unit.globals.len(), 1);
+        assert!(tir_unit.globals.raw[0].ty.is_array());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: using layout computation through BuilderCtx.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn layout_computation_through_builder_ctx() {
+    BuilderCtx::with_default(|ctx| {
+        let i32_ty = ctx.i32();
+        let layout = ctx.layout_of(i32_ty);
+        assert_eq!(layout.layout.size.bytes(), 4);
+
+        let i64_ty = ctx.i64();
+        let layout = ctx.layout_of(i64_ty);
+        assert_eq!(layout.layout.size.bytes(), 8);
+
+        let unit_ty = ctx.unit();
+        let layout = ctx.layout_of(unit_ty);
+        assert_eq!(layout.layout.size.bytes(), 0);
     });
 }

--- a/compiler/tidec_builder/tests/integration_tests.rs
+++ b/compiler/tidec_builder/tests/integration_tests.rs
@@ -1,0 +1,574 @@
+//! Integration tests for `tidec_builder`.
+//!
+//! Each test constructs a complete TIR module end-to-end using the builder API
+//! and then asserts on the resulting structure.
+
+use std::num::NonZero;
+
+use tidec_abi::target::{BackendKind, TirTarget};
+use tidec_builder::{BasicBlockBuilder, FunctionBuilder, UnitBuilder};
+use tidec_tir::body::*;
+use tidec_tir::ctx::{EmitKind, InternCtx, TirArena, TirArgs, TirCtx};
+use tidec_tir::syntax::*;
+use tidec_tir::ty;
+use tidec_utils::idx::Idx;
+
+/// Helper to run a closure with a fresh `TirCtx`.
+fn with_ctx<F, R>(f: F) -> R
+where
+    F: for<'ctx> FnOnce(TirCtx<'ctx>) -> R,
+{
+    let target = TirTarget::new(BackendKind::Llvm);
+    let args = TirArgs {
+        emit_kind: EmitKind::Object,
+    };
+    let arena = TirArena::default();
+    let intern_ctx = InternCtx::new(&arena);
+    let tir_ctx = TirCtx::new(&target, &args, &intern_ctx);
+    f(tir_ctx)
+}
+
+fn make_metadata(name: &str) -> TirBodyMetadata {
+    TirBodyMetadata {
+        def_id: DefId(0),
+        name: name.to_string(),
+        kind: TirBodyKind::Item(TirItemKind::Function),
+        inlined: false,
+        linkage: Linkage::External,
+        visibility: Visibility::Default,
+        unnamed_address: UnnamedAddress::None,
+        call_conv: CallConv::C,
+        is_varargs: false,
+        is_declaration: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test: build a simple `add(a, b) -> a + b` function inside a module.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_add_function_module() {
+    with_ctx(|ctx| {
+        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+        // -- Build the function body: i32 add(i32 %a, i32 %b) { return %a + %b; }
+        let mut fb = FunctionBuilder::new(make_metadata("add"));
+
+        // _0: i32 (return place)
+        let ret = fb.declare_ret(i32_ty, false);
+        assert_eq!(ret, RETURN_LOCAL);
+
+        // _1: i32 (first arg)
+        let arg_a = fb.declare_arg(i32_ty, false);
+        // _2: i32 (second arg)
+        let arg_b = fb.declare_arg(i32_ty, false);
+
+        assert_eq!(fb.num_args(), 2);
+        assert_eq!(fb.num_locals(), 3); // ret + 2 args
+
+        // Create entry block
+        let entry = fb.create_block();
+
+        // entry:
+        //   _0 = Add(_1, _2)
+        //   return
+        fb.push_assign(
+            entry,
+            Place::from(RETURN_LOCAL),
+            RValue::BinaryOp(
+                BinaryOp::Add,
+                Operand::Use(Place::from(arg_a)),
+                Operand::Use(Place::from(arg_b)),
+            ),
+        );
+        fb.set_terminator(entry, Terminator::Return);
+
+        let body = fb.build();
+
+        // Verify the body structure.
+        assert_eq!(body.metadata.name, "add");
+        assert_eq!(body.ret_and_args.len(), 3); // ret + 2 args
+        assert!(body.locals.is_empty()); // no extra locals
+        assert_eq!(body.basic_blocks.len(), 1);
+
+        let bb0 = &body.basic_blocks[BasicBlock::new(0)];
+        assert_eq!(bb0.statements.len(), 1);
+        assert!(matches!(bb0.terminator, Terminator::Return));
+
+        // -- Wrap the body in a module.
+        let mut unit = UnitBuilder::new("add_module");
+        let body_id = unit.add_body(body);
+        assert!(body_id.idx() == 0);
+        assert_eq!(unit.num_bodies(), 1);
+
+        let tir_unit = unit.build();
+        assert_eq!(tir_unit.metadata.unit_name, "add_module");
+        assert_eq!(tir_unit.bodies.len(), 1);
+        assert!(tir_unit.globals.is_empty());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: build a function with a global variable and a branch.
+//
+//   global counter: i32 = 0
+//
+//   fn maybe_increment(cond: bool) -> i32 {
+//       if cond { counter + 1 } else { counter }
+//   }
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_module_with_global_and_branch() {
+    with_ctx(|ctx| {
+        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+        let bool_ty = ctx.intern_ty(ty::TirTy::Bool);
+
+        // -- Global: `counter = 0`
+        let scalar_zero = ConstScalar::Value(RawScalarValue {
+            data: 0,
+            size: NonZero::new(4).unwrap(),
+        });
+        let global = TirGlobal {
+            name: "counter".to_string(),
+            ty: i32_ty,
+            initializer: Some(ConstValue::Scalar(scalar_zero)),
+            mutable: true,
+            linkage: Linkage::Internal,
+            visibility: Visibility::Default,
+            unnamed_address: UnnamedAddress::None,
+        };
+
+        // -- Function: maybe_increment
+        let mut fb = FunctionBuilder::new(make_metadata("maybe_increment"));
+        let _ret = fb.declare_ret(i32_ty, false);
+        let cond = fb.declare_arg(bool_ty, false);
+        let counter_local = fb.declare_local(i32_ty, false); // _3, holds loaded counter
+        let tmp = fb.declare_local(i32_ty, true); // _4, holds counter+1
+
+        // entry: switch on cond -> then_bb / else_bb
+        let entry = fb.create_block();
+        let then_bb = fb.create_block();
+        let else_bb = fb.create_block();
+        let merge_bb = fb.create_block();
+
+        assert_eq!(fb.num_blocks(), 4);
+
+        // entry: switchInt(cond) [1 -> then_bb, otherwise -> else_bb]
+        fb.set_terminator(
+            entry,
+            Terminator::SwitchInt {
+                discr: Operand::Use(Place::from(cond)),
+                targets: SwitchTargets::if_then(then_bb, else_bb),
+            },
+        );
+
+        // then_bb: _4 = _3 + 1; _0 = _4; goto merge
+        {
+            let one = ConstOperand::Value(
+                ConstValue::Scalar(ConstScalar::Value(RawScalarValue {
+                    data: 1,
+                    size: NonZero::new(4).unwrap(),
+                })),
+                i32_ty,
+            );
+            let mut bb = BasicBlockBuilder::new();
+            bb.push_assign_binary_op(
+                Place::from(tmp),
+                BinaryOp::Add,
+                Operand::Use(Place::from(counter_local)),
+                Operand::Const(one),
+            );
+            bb.push_assign_operand(Place::from(RETURN_LOCAL), Operand::Use(Place::from(tmp)));
+            let data = bb.build(Terminator::Goto { target: merge_bb });
+            fb.apply_block_builder(then_bb, data);
+        }
+
+        // else_bb: _0 = _3; goto merge
+        fb.push_assign(
+            else_bb,
+            Place::from(RETURN_LOCAL),
+            RValue::Operand(Operand::Use(Place::from(counter_local))),
+        );
+        fb.set_terminator(else_bb, Terminator::Goto { target: merge_bb });
+
+        // merge_bb: return
+        fb.set_terminator(merge_bb, Terminator::Return);
+
+        let body = fb.build();
+
+        // Verify function structure.
+        assert_eq!(body.ret_and_args.len(), 2); // ret + cond
+        assert_eq!(body.locals.len(), 2); // counter_local + tmp
+        assert_eq!(body.basic_blocks.len(), 4);
+
+        // Verify then_bb has 2 statements (add + assign).
+        let then_data = &body.basic_blocks[then_bb];
+        assert_eq!(then_data.statements.len(), 2);
+        assert!(matches!(
+            then_data.terminator,
+            Terminator::Goto { target } if target == merge_bb
+        ));
+
+        // Verify else_bb has 1 statement (assign).
+        let else_data = &body.basic_blocks[else_bb];
+        assert_eq!(else_data.statements.len(), 1);
+
+        // Verify merge_bb has no statements, just return.
+        let merge_data = &body.basic_blocks[merge_bb];
+        assert!(merge_data.statements.is_empty());
+        assert!(matches!(merge_data.terminator, Terminator::Return));
+
+        // -- Assemble the module.
+        let mut unit = UnitBuilder::new("branch_module");
+        let gid = unit.add_global(global);
+        let bid = unit.add_body(body);
+
+        assert_eq!(unit.num_globals(), 1);
+        assert_eq!(unit.num_bodies(), 1);
+        assert_eq!(unit.get_global(gid).name, "counter");
+        assert_eq!(unit.get_body(&bid).metadata.name, "maybe_increment");
+
+        let tir_unit = unit.build();
+        assert_eq!(tir_unit.metadata.unit_name, "branch_module");
+        assert_eq!(tir_unit.globals.len(), 1);
+        assert_eq!(tir_unit.bodies.len(), 1);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: build a declaration-only (extern) function and a calling function.
+//
+//   declare i32 @ext_fn(i32)
+//
+//   define i32 @caller(i32 %x) {
+//     _2 = call @ext_fn(%x)
+//     return _2
+//   }
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_module_with_declaration_and_call() {
+    with_ctx(|ctx| {
+        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+        // -- External declaration: i32 ext_fn(i32)
+        let mut ext_meta = make_metadata("ext_fn");
+        ext_meta.is_declaration = true;
+        ext_meta.def_id = DefId(0);
+        let mut ext_fb = FunctionBuilder::new(ext_meta);
+        ext_fb.declare_ret(i32_ty, false);
+        ext_fb.declare_arg(i32_ty, false);
+        // Declarations don't need blocks.
+        // We add a dummy unreachable block so the builder doesn't complain.
+        let ext_entry = ext_fb.create_block();
+        ext_fb.set_terminator(ext_entry, Terminator::Unreachable);
+        let ext_body = ext_fb.build();
+
+        assert!(ext_body.metadata.is_declaration);
+        assert_eq!(ext_body.metadata.name, "ext_fn");
+
+        // -- Caller function: i32 caller(i32 %x) { return ext_fn(%x); }
+        let mut caller_meta = make_metadata("caller");
+        caller_meta.def_id = DefId(1);
+        let mut caller_fb = FunctionBuilder::new(caller_meta);
+
+        let _ret = caller_fb.declare_ret(i32_ty, false);
+        let x = caller_fb.declare_arg(i32_ty, false);
+        let dest = caller_fb.declare_local(i32_ty, true);
+
+        let entry = caller_fb.create_block();
+        let cont = caller_fb.create_block();
+
+        // entry: _2 = call ext_fn(_1); goto cont
+        // We use _1 as a stand-in operand for the function pointer (simplified).
+        caller_fb.set_terminator(
+            entry,
+            Terminator::Call {
+                func: Operand::Use(Place::from(x)), // placeholder
+                args: vec![Operand::Use(Place::from(x))],
+                destination: Place::from(dest),
+                target: cont,
+            },
+        );
+
+        // cont: _0 = _2; return
+        caller_fb.push_assign(
+            cont,
+            Place::from(RETURN_LOCAL),
+            RValue::Operand(Operand::Use(Place::from(dest))),
+        );
+        caller_fb.set_terminator(cont, Terminator::Return);
+
+        let caller_body = caller_fb.build();
+
+        assert_eq!(caller_body.basic_blocks.len(), 2);
+        assert!(matches!(
+            caller_body.basic_blocks[BasicBlock::new(0)].terminator,
+            Terminator::Call { .. }
+        ));
+
+        // -- Assemble the module.
+        let mut unit = UnitBuilder::new("call_module");
+        unit.add_body(ext_body);
+        unit.add_body(caller_body);
+
+        assert_eq!(unit.num_bodies(), 2);
+
+        let tir_unit = unit.build();
+        assert_eq!(tir_unit.bodies.len(), 2);
+        assert_eq!(tir_unit.bodies.raw[0].metadata.name, "ext_fn");
+        assert_eq!(tir_unit.bodies.raw[1].metadata.name, "caller");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: build a module with struct aggregate construction.
+//
+//   struct Pair { i32, f64 }
+//
+//   define Pair @make_pair(i32 %a, f64 %b) {
+//       _3 = Aggregate::Struct(Pair, [%a, %b])
+//       _0 = _3
+//       return
+//   }
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_module_with_struct_aggregate() {
+    with_ctx(|ctx| {
+        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+        let f64_ty = ctx.intern_ty(ty::TirTy::F64);
+
+        let fields = ctx.intern_type_list(&[i32_ty, f64_ty]);
+        let pair_ty = ctx.intern_ty(ty::TirTy::Struct {
+            fields,
+            packed: false,
+        });
+
+        let mut fb = FunctionBuilder::new(make_metadata("make_pair"));
+        fb.declare_ret(pair_ty, false);
+        let a = fb.declare_arg(i32_ty, false);
+        let b = fb.declare_arg(f64_ty, false);
+        let tmp = fb.declare_local(pair_ty, false);
+
+        let entry = fb.create_block();
+
+        // _3 = Aggregate::Struct(pair_ty, [_1, _2])
+        fb.push_assign(
+            entry,
+            Place::from(tmp),
+            RValue::Aggregate(
+                AggregateKind::Struct(pair_ty),
+                vec![Operand::Use(Place::from(a)), Operand::Use(Place::from(b))],
+            ),
+        );
+        // _0 = _3
+        fb.push_assign(
+            entry,
+            Place::from(RETURN_LOCAL),
+            RValue::Operand(Operand::Use(Place::from(tmp))),
+        );
+        fb.set_terminator(entry, Terminator::Return);
+
+        let body = fb.build();
+        assert_eq!(body.basic_blocks[BasicBlock::new(0)].statements.len(), 2);
+
+        let mut unit = UnitBuilder::new("struct_module");
+        unit.add_body(body);
+        let tir_unit = unit.build();
+
+        assert_eq!(tir_unit.bodies.len(), 1);
+        assert_eq!(tir_unit.bodies.raw[0].metadata.name, "make_pair");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: build a module with a cast (int → float).
+//
+//   define f64 @int_to_float(i32 %x) {
+//       _0 = IntToFloat(_1) as f64
+//       return
+//   }
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_module_with_cast() {
+    with_ctx(|ctx| {
+        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+        let f64_ty = ctx.intern_ty(ty::TirTy::F64);
+
+        let mut fb = FunctionBuilder::new(make_metadata("int_to_float"));
+        fb.declare_ret(f64_ty, false);
+        let x = fb.declare_arg(i32_ty, false);
+
+        let entry = fb.create_block();
+
+        // Use BasicBlockBuilder for variety.
+        let mut bb = BasicBlockBuilder::new();
+        bb.push_assign_cast(
+            Place::from(RETURN_LOCAL),
+            CastKind::IntToFloat,
+            Operand::Use(Place::from(x)),
+            f64_ty,
+        );
+        let data = bb.build(Terminator::Return);
+
+        fb.apply_block_builder(entry, data);
+
+        let body = fb.build();
+        assert_eq!(body.basic_blocks.len(), 1);
+        assert_eq!(body.basic_blocks[BasicBlock::new(0)].statements.len(), 1);
+
+        let mut unit = UnitBuilder::new("cast_module");
+        unit.add_body(body);
+        let tir_unit = unit.build();
+
+        assert_eq!(tir_unit.metadata.unit_name, "cast_module");
+        assert_eq!(tir_unit.bodies.len(), 1);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: build a module with an address-of operation.
+//
+//   define *imm i32 @take_addr(i32 %x) {
+//       _0 = &imm _1
+//       return
+//   }
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_module_with_address_of() {
+    with_ctx(|ctx| {
+        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+        let ptr_ty = ctx.intern_ty(ty::TirTy::RawPtr(i32_ty, ty::Mutability::Imm));
+
+        let mut fb = FunctionBuilder::new(make_metadata("take_addr"));
+        fb.declare_ret(ptr_ty, false);
+        let x = fb.declare_arg(i32_ty, false);
+
+        let entry = fb.create_block();
+
+        let mut bb = BasicBlockBuilder::new();
+        bb.push_assign_address_of(
+            Place::from(RETURN_LOCAL),
+            ty::Mutability::Imm,
+            Place::from(x),
+        );
+        fb.apply_block_builder(entry, bb.build(Terminator::Return));
+
+        let body = fb.build();
+
+        let mut unit = UnitBuilder::new("addr_module");
+        unit.add_body(body);
+        let tir_unit = unit.build();
+
+        assert_eq!(tir_unit.bodies.len(), 1);
+        assert_eq!(tir_unit.bodies.raw[0].metadata.name, "take_addr");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: build a module with multiple globals and multiple functions.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_large_module() {
+    with_ctx(|ctx| {
+        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+        let unit_ty = ctx.intern_ty(ty::TirTy::Unit);
+
+        let mut unit = UnitBuilder::new("large_module");
+
+        // Add 5 globals.
+        for i in 0..5 {
+            let global = TirGlobal {
+                name: format!("g{}", i),
+                ty: i32_ty,
+                initializer: Some(ConstValue::Scalar(ConstScalar::Value(RawScalarValue {
+                    data: i as u128,
+                    size: NonZero::new(4).unwrap(),
+                }))),
+                mutable: i % 2 == 0,
+                linkage: Linkage::External,
+                visibility: Visibility::Default,
+                unnamed_address: UnnamedAddress::None,
+            };
+            unit.add_global(global);
+        }
+
+        // Add 3 trivial functions.
+        for i in 0..3 {
+            let ret_ty = if i == 0 { unit_ty } else { i32_ty };
+            let mut fb = FunctionBuilder::new(make_metadata(&format!("fn_{}", i)));
+            fb.declare_ret(ret_ty, false);
+            let entry = fb.create_block();
+            fb.set_terminator(entry, Terminator::Return);
+            unit.add_body(fb.build());
+        }
+
+        assert_eq!(unit.num_globals(), 5);
+        assert_eq!(unit.num_bodies(), 3);
+
+        let tir_unit = unit.build();
+        assert_eq!(tir_unit.metadata.unit_name, "large_module");
+        assert_eq!(tir_unit.globals.len(), 5);
+        assert_eq!(tir_unit.bodies.len(), 3);
+
+        // Verify global names.
+        for i in 0..5 {
+            assert_eq!(tir_unit.globals.raw[i].name, format!("g{}", i));
+        }
+
+        // Verify function names.
+        for i in 0..3 {
+            assert_eq!(tir_unit.bodies.raw[i].metadata.name, format!("fn_{}", i));
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Test: using BasicBlockBuilder chaining API with unary operations.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chaining_basic_block_builder_in_function() {
+    with_ctx(|ctx| {
+        let i32_ty = ctx.intern_ty(ty::TirTy::I32);
+
+        let mut fb = FunctionBuilder::new(make_metadata("neg_and_not"));
+        fb.declare_ret(i32_ty, false);
+        let x = fb.declare_arg(i32_ty, false);
+        let neg_tmp = fb.declare_local(i32_ty, true);
+
+        let entry = fb.create_block();
+
+        let mut bb = BasicBlockBuilder::new();
+        // _2 = Neg(_1)
+        // _0 = Not(_2)
+        bb.push_assign_unary_op(
+            Place::from(neg_tmp),
+            UnaryOp::Neg,
+            Operand::Use(Place::from(x)),
+        )
+        .push_assign_unary_op(
+            Place::from(RETURN_LOCAL),
+            UnaryOp::Not,
+            Operand::Use(Place::from(neg_tmp)),
+        );
+
+        assert_eq!(bb.len(), 2);
+        fb.apply_block_builder(entry, bb.build(Terminator::Return));
+
+        let body = fb.build();
+        assert_eq!(body.basic_blocks[BasicBlock::new(0)].statements.len(), 2);
+
+        let unit = UnitBuilder::new("chain_mod");
+        // We intentionally leave the module with zero bodies, just to show the
+        // builder allows it.
+        let tir_unit = unit.build();
+        assert!(tir_unit.bodies.is_empty());
+    });
+}


### PR DESCRIPTION
This pull request introduces a new `tidec_builder` crate to the project, providing a high-level, ergonomic API for constructing Tide IR (TIR) programmatically. The main codebase and tests are refactored to use this new API for type construction, resulting in cleaner and more maintainable code. The changes also include updates to the project configuration files to integrate the new crate.

**Introduction of the `tidec_builder` crate:**

* Added the new `tidec_builder` crate, which provides builder types (`BuilderCtx`, `UnitBuilder`, `FunctionBuilder`, `BasicBlockBuilder`) to simplify and standardize the construction of TIR types, function bodies, and basic blocks. The crate includes documentation and tests for its API. [[1]](diffhunk://#diff-5fe5b872dc673b3b8436b9a30989d4a14b9eb214d5599cc026e6db3321312b39R1-R12) [[2]](diffhunk://#diff-1c3e23f9bd49a627c442186d1a173709e291f1d75f235514fc44e8b34928e50bR1-R48) [[3]](diffhunk://#diff-f6858dbabc49bac48f6473ad5da87c752164173cc22c3aee59aa1071992f0779R1-R260)

**Integration and refactoring in the main compiler and tests:**

* Updated `compiler/tidec` and its tests to use `BuilderCtx` from `tidec_builder` for creating TIR types (such as `i32`, `i8`, and pointer types), replacing manual interning and direct construction. This results in more readable and maintainable code in both the main source and test files. [[1]](diffhunk://#diff-b7b919dd2a6343a516838a8e15b875a6d6a54722e22bf7ac8aa7aab690cbc8d5L35-R40) [[2]](diffhunk://#diff-b7b919dd2a6343a516838a8e15b875a6d6a54722e22bf7ac8aa7aab690cbc8d5R270-R277) [[3]](diffhunk://#diff-b7b919dd2a6343a516838a8e15b875a6d6a54722e22bf7ac8aa7aab690cbc8d5L288-R294) [[4]](diffhunk://#diff-0088dbbf57f921ac2156feba8a87e02de6a7804a0c940f9e2f272052363eec2dR9) [[5]](diffhunk://#diff-0088dbbf57f921ac2156feba8a87e02de6a7804a0c940f9e2f272052363eec2dL18-R27) [[6]](diffhunk://#diff-223c2fa3fae26867d0111afb46e361dc300af8c5fda08a28c7535f3946c58107R8) [[7]](diffhunk://#diff-223c2fa3fae26867d0111afb46e361dc300af8c5fda08a28c7535f3946c58107L17-R23) [[8]](diffhunk://#diff-9cb509f03faba8c445ac5378ad4c48ea6eb2889c292765189d151bc806e8b31fR8) [[9]](diffhunk://#diff-9cb509f03faba8c445ac5378ad4c48ea6eb2889c292765189d151bc806e8b31fL17-R23) [[10]](diffhunk://#diff-98d5a520ea123e0f61a4e5e539f707e11be2c1aec2b8577d9e841df3bf93f481R8) [[11]](diffhunk://#diff-98d5a520ea123e0f61a4e5e539f707e11be2c1aec2b8577d9e841df3bf93f481L17-R23)

**Project configuration updates:**

* Registered `tidec_builder` as a workspace member in the root `Cargo.toml` and added it as a dependency to `compiler/tidec`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R7) [[2]](diffhunk://#diff-9f37a877717352042f0e8691014c1f55085205494d37b3abb0ef8d991b804bc1R13-R16)

**Documentation improvements:**

* Clarified in `README.md` that the TIR is a "backend-agnostic non-textual intermediate representation."